### PR TITLE
Issue #83 replacement with ValidatorId

### DIFF
--- a/domain/src/balances_map.rs
+++ b/domain/src/balances_map.rs
@@ -54,7 +54,7 @@ impl BalancesMap {
 
             if fee_rounded > 0.into() {
                 let entry = balances
-                    .entry(validator.id.clone())
+                    .entry(validator.id.clone().into())
                     .or_insert_with(|| 0.into());
 
                 *entry += &fee_rounded;

--- a/domain/src/channel.rs
+++ b/domain/src/channel.rs
@@ -9,7 +9,9 @@ use serde_hex::{SerHex, StrictPfx};
 
 use crate::big_num::BigNum;
 use crate::util::serde::ts_milliseconds_option;
-use crate::{AdUnit, Asset, DomainError, EventSubmission, TargetingTag, ValidatorDesc};
+use crate::{
+    AdUnit, Asset, DomainError, EventSubmission, TargetingTag, ValidatorDesc, ValidatorId,
+};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Copy, Clone)]
 #[serde(transparent)]
@@ -195,10 +197,10 @@ impl SpecValidators {
         &self.0[1]
     }
 
-    pub fn find(&self, validator_id: &str) -> SpecValidator<'_> {
-        if self.leader().id == validator_id {
+    pub fn find(&self, validator: &ValidatorId) -> SpecValidator<'_> {
+        if &self.leader().id == validator {
             SpecValidator::Leader(&self.leader())
-        } else if self.follower().id == validator_id {
+        } else if &self.follower().id == validator {
             SpecValidator::Follower(&self.follower())
         } else {
             SpecValidator::None

--- a/domain/src/validator.rs
+++ b/domain/src/validator.rs
@@ -22,6 +22,12 @@ impl TryFrom<&str> for ValidatorId {
     }
 }
 
+impl Into<String> for ValidatorId {
+    fn into(self) -> String {
+        self.0
+    }
+}
+
 impl AsRef<str> for ValidatorId {
     fn as_ref(&self) -> &str {
         self.0.as_str()
@@ -37,8 +43,7 @@ impl fmt::Display for ValidatorId {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ValidatorDesc {
-    // @TODO: Replace id `String` with `ValidatorId` https://github.com/AdExNetwork/adex-validator-stack-rust/issues/83
-    pub id: String,
+    pub id: ValidatorId,
     pub url: String,
     pub fee: BigNum,
 }
@@ -47,9 +52,9 @@ pub struct ValidatorDesc {
 pub mod fixtures {
     use fake::faker::*;
 
+    use super::{ValidatorDesc, ValidatorId};
     use crate::BigNum;
-
-    use super::ValidatorDesc;
+    use std::convert::TryFrom;
 
     pub fn get_validator<V: AsRef<str>>(validator_id: V, fee: Option<BigNum>) -> ValidatorDesc {
         let fee = fee.unwrap_or_else(|| BigNum::from(<Faker as Number>::between(1, 13)));
@@ -57,9 +62,11 @@ pub mod fixtures {
             "http://{}-validator-url.com/validator",
             validator_id.as_ref()
         );
+        let validator_id =
+            ValidatorId::try_from(validator_id.as_ref()).expect("Creating ValidatorId failed");
 
         ValidatorDesc {
-            id: validator_id.as_ref().to_string(),
+            id: validator_id,
             url,
             fee,
         }

--- a/sentry/src/application/resource/channel.rs
+++ b/sentry/src/application/resource/channel.rs
@@ -54,13 +54,13 @@ impl ChannelListQuery {
         }
     }
 
-    pub fn validator(&self) -> Option<String> {
-        self.validator.to_owned().and_then(|s| {
+    pub fn validator(&self) -> Option<&str> {
+        self.validator.as_ref().and_then(|s| {
             if s.is_empty() {
                 return None;
             }
 
-            Some(s)
+            Some(s.as_str())
         })
     }
 }

--- a/sentry/src/application/resource/channel/channel_list/handler.rs
+++ b/sentry/src/application/resource/channel/channel_list/handler.rs
@@ -22,10 +22,10 @@ impl ChannelListHandler {
 
 impl ChannelListHandler {
     #[allow(clippy::needless_lifetimes)]
-    pub async fn handle(
-        &self,
+    pub async fn handle<'a>(
+        &'a self,
         page: u64,
-        validator: Option<String>,
+        validator: Option<&'a str>,
     ) -> Result<ChannelListResponse, ()> {
         let channel_list_params =
             ChannelListParams::new(Utc::now(), self.limit_per_page, page, validator)

--- a/sentry/src/infrastructure/persistence/channel/memory_test.rs
+++ b/sentry/src/infrastructure/persistence/channel/memory_test.rs
@@ -151,8 +151,7 @@ fn listing_channels_can_handles_validator_filtration_and_keeps_valid_until_filtr
 
         let repository = MemoryChannelRepository::new(Some(&channels));
 
-        let params =
-            ChannelListParams::new(valid_until_ge, 10, 1, Some("validator-1".to_string())).unwrap();
+        let params = ChannelListParams::new(valid_until_ge, 10, 1, Some("validator-1")).unwrap();
         let list_channels = await!(repository.list(&params)).expect("Should list all channels");
 
         assert_eq!(1, list_channels.len());

--- a/validator/src/application/message_propagation.rs
+++ b/validator/src/application/message_propagation.rs
@@ -1,9 +1,8 @@
-use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
 
 use domain::validator::message::{Message, State};
-use domain::{Channel, RepositoryError, ValidatorId};
+use domain::{Channel, RepositoryError};
 
 use crate::domain::MessageRepository;
 
@@ -55,12 +54,10 @@ impl<S: State> MessagePropagator<S> {
         let mut results = Vec::default();
 
         for validator in channel.spec.validators.into_iter() {
-            // @TODO: Remove once we have ValidatorId in ValidatorDesc
-            let validator_id = ValidatorId::try_from(validator.id.as_str()).unwrap();
             let add_result =
                 await!(self
                     .message_repository
-                    .add(&channel.id, &validator_id, message.clone()))
+                    .add(&channel.id, &validator.id, message.clone()))
                 .map_err(Into::into);
             results.push(add_result);
         }

--- a/validator/src/application/worker.rs
+++ b/validator/src/application/worker.rs
@@ -49,7 +49,11 @@ pub mod single {
         async fn handle_channel(self, channel: Channel) -> Result<(), ()> {
             let channel_id = channel.id;
 
-            match &channel.spec.validators.find(&self.identity) {
+            // @TODO: Update once we figure out if ValidatorId can fail from a &str
+            let validator_id = ValidatorId::try_from(self.identity.as_str())
+                .expect("ValidatorId doesn't have a failing case right now");
+
+            match &channel.spec.validators.find(&validator_id) {
                 SpecValidator::Leader(_) => {
                     let tick_future = self.leader.tick(channel);
 

--- a/validator/src/infrastructure/persistence/channel/memory.rs
+++ b/validator/src/infrastructure/persistence/channel/memory.rs
@@ -24,13 +24,12 @@ impl MemoryChannelRepository {
 
 impl ChannelRepository for MemoryChannelRepository {
     fn all(&self, identity: &ValidatorId) -> RepositoryFuture<Vec<Channel>> {
-        let list =
-            self.inner.list_all(
-                |channel| match channel.spec.validators.find(identity.as_ref()) {
-                    SpecValidator::Leader(_) | SpecValidator::Follower(_) => Some(channel.clone()),
-                    SpecValidator::None => None,
-                },
-            );
+        let list = self
+            .inner
+            .list_all(|channel| match channel.spec.validators.find(identity) {
+                SpecValidator::Leader(_) | SpecValidator::Follower(_) => Some(channel.clone()),
+                SpecValidator::None => None,
+            });
 
         ready(list.map_err(Into::into)).boxed()
     }


### PR DESCRIPTION
Resolves #83 
For now not every place makes total sense and can be definitely be cleaner, but for the current state this is sufficient to have the `ValidatorId` in the Domain where it's needed for arguments and etc. instead of having Strings