### PR TITLE
Various review-related changes

### DIFF
--- a/primitives/src/util.rs
+++ b/primitives/src/util.rs
@@ -1,15 +1,6 @@
 pub mod tests {
-    use rand::seq::SliceRandom;
-    use rand::thread_rng;
-
     pub mod prep_db;
     pub mod time;
-
-    #[inline]
-    pub fn take_one<'a, T: ?Sized>(list: &[&'a T]) -> &'a T {
-        let mut rng = thread_rng();
-        list.choose(&mut rng).expect("take_one got empty list")
-    }
 }
 
 pub mod serde {

--- a/primitives/src/validator.rs
+++ b/primitives/src/validator.rs
@@ -65,9 +65,7 @@ impl TryFrom<&str> for ValidatorId {
 impl TryFrom<&String> for ValidatorId {
     type Error = DomainError;
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        ValidatorId::try_from(value.as_str()).map_err(|_| {
-            DomainError::InvalidArgument("Failed to deserialize validator id".to_string())
-        })
+        ValidatorId::try_from(value.as_str())
     }
 }
 

--- a/validator_worker/src/sentry_interface.rs
+++ b/validator_worker/src/sentry_interface.rs
@@ -108,7 +108,7 @@ impl<T: Adapter + 'static> SentryApi<T> {
             .compat()
             .await?;
 
-        Ok(result.validator_messages.get(0).map(|m| m.msg.clone()))
+        Ok(result.validator_messages.first().map(|m| m.msg.clone()))
     }
 
     pub async fn get_our_latest_msg(

--- a/validator_worker/src/sentry_interface.rs
+++ b/validator_worker/src/sentry_interface.rs
@@ -107,11 +107,8 @@ impl<T: Adapter + 'static> SentryApi<T> {
             .and_then(|mut res: Response| res.json::<ValidatorMessageResponse>())
             .compat()
             .await?;
-        if !result.validator_messages.is_empty() {
-            return Ok(Some(result.validator_messages[0].msg.clone()));
-        }
 
-        Ok(None)
+        Ok(result.validator_messages.get(0).map(|m| m.msg.clone()))
     }
 
     pub async fn get_our_latest_msg(


### PR DESCRIPTION
- Get rid of an array indexing; the reason we should avoid cases like this is that I `grep` the codebase for array and slice indexing to check if it can panic, cause it's one of the most common errors in Rust; so in this case, it cannot panic because there is an `if !x.is_empty()` before, but why do this when it can be written much more elegantly: use `.first()` which already returns an option, and map it
- remove an `map_err` which, other than being unnecessary, actually deleted details about the error
- util: remove `take_one`, does not seem to be used