### PR TITLE
SpecValidators tuple instead of array

### DIFF
--- a/primitives/src/channel.rs
+++ b/primitives/src/channel.rs
@@ -70,8 +70,8 @@ pub struct ChannelSpec {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(transparent)]
-pub struct SpecValidators([ValidatorDesc; 2]);
+/// A (leader, follower) tuple
+pub struct SpecValidators(ValidatorDesc, ValidatorDesc);
 
 pub enum SpecValidator<'a> {
     Leader(&'a ValidatorDesc),
@@ -94,15 +94,15 @@ impl<'a> SpecValidator<'a> {
 
 impl SpecValidators {
     pub fn new(leader: ValidatorDesc, follower: ValidatorDesc) -> Self {
-        Self([leader, follower])
+        Self(leader, follower)
     }
 
     pub fn leader(&self) -> &ValidatorDesc {
-        &self.0[0]
+        &self.0
     }
 
     pub fn follower(&self) -> &ValidatorDesc {
-        &self.0[1]
+        &self.1
     }
 
     pub fn find(&self, validator_id: &ValidatorId) -> SpecValidator<'_> {
@@ -116,12 +116,13 @@ impl SpecValidators {
     }
 }
 
-impl From<[ValidatorDesc; 2]> for SpecValidators {
-    fn from(slice: [ValidatorDesc; 2]) -> Self {
-        Self(slice)
+impl From<(ValidatorDesc, ValidatorDesc)> for SpecValidators {
+    fn from((leader, follower): (ValidatorDesc, ValidatorDesc)) -> Self {
+        Self(leader, follower)
     }
 }
 
+/// Fixed size iterator of 2, as we need an iterator in couple of occasions
 impl<'a> IntoIterator for &'a SpecValidators {
     type Item = &'a ValidatorDesc;
     type IntoIter = ::std::vec::IntoIter<Self::Item>;

--- a/validator_worker/src/core/events.rs
+++ b/validator_worker/src/core/events.rs
@@ -100,7 +100,7 @@ mod test {
             deposit_amount: 10_000.into(),
             ..DUMMY_CHANNEL.clone()
         };
-        channel.spec.validators = [leader, follower].into();
+        channel.spec.validators = (leader, follower).into();
 
         let balances_before_fees: BalancesMap =
             vec![("a".to_string(), 100.into()), ("b".to_string(), 200.into())]
@@ -141,7 +141,7 @@ mod test {
         };
 
         let spec = ChannelSpec {
-            validators: [leader, follower].into(),
+            validators: (leader, follower).into(),
             ..DUMMY_CHANNEL.spec.clone()
         };
         let channel = Channel {

--- a/validator_worker/src/core/fees.rs
+++ b/validator_worker/src/core/fees.rs
@@ -161,7 +161,7 @@ mod test {
             };
 
             let mut spec = DUMMY_CHANNEL.spec.clone();
-            spec.validators = [leader, follower].into();
+            spec.validators = (leader, follower).into();
 
             Channel {
                 deposit_amount: 100_000.into(),
@@ -185,7 +185,7 @@ mod test {
             };
 
             let mut spec = DUMMY_CHANNEL.spec.clone();
-            spec.validators = [leader, follower].into();
+            spec.validators = (leader, follower).into();
 
             let channel = Channel {
                 deposit_amount: 10_000.into(),
@@ -315,7 +315,7 @@ mod test {
         };
 
         let mut spec = DUMMY_CHANNEL.spec.clone();
-        spec.validators = [leader, follower].into();
+        spec.validators = (leader, follower).into();
 
         let channel = Channel {
             deposit_amount: 1_000.into(),


### PR DESCRIPTION
- Switch to a tuple in the struct to hold the (Leader, Follower) pair
- Change the `impl From`  from array to tuple