### PR TITLE
feeAddr + casing fixes

### DIFF
--- a/adapter/src/dummy.rs
+++ b/adapter/src/dummy.rs
@@ -43,7 +43,7 @@ impl Adapter for DummyAdapter {
         let signature = format!(
             "Dummy adapter signature for {} by {}",
             state_root,
-            self.whoami()
+            self.whoami().to_hex_checksummed_string()
         );
         Ok(signature)
     }
@@ -57,7 +57,7 @@ impl Adapter for DummyAdapter {
         // select the `identity` and compare it to the signer
         // for empty string this will return array with 1 element - an empty string `[""]`
         let is_same = match signature.rsplit(' ').take(1).next() {
-            Some(from) => from == signer.to_string(),
+            Some(from) => from == signer.to_hex_checksummed_string(),
             None => false,
         };
 

--- a/adapter/src/ethereum.rs
+++ b/adapter/src/ethereum.rs
@@ -547,6 +547,7 @@ mod test {
                 .expect("failed to create id"),
             url: "http://localhost:8005".to_string(),
             fee: 100.into(),
+            fee_addr: None,
         };
 
         let follower_validator_desc = ValidatorDesc {
@@ -555,6 +556,7 @@ mod test {
                 .expect("failed to create id"),
             url: "http://localhost:8006".to_string(),
             fee: 100.into(),
+            fee_addr: None,
         };
 
         let mut valid_channel = Channel {

--- a/primitives/src/util/tests/prep_db.rs
+++ b/primitives/src/util/tests/prep_db.rs
@@ -45,12 +45,14 @@ lazy_static! {
         id:  ValidatorId::try_from("ce07CbB7e054514D590a0262C93070D838bFBA2e").expect("Failed to parse DUMMY_VALIDATOR_LEADER id "),
         url: "http://localhost:8005".to_string(),
         fee: 100.into(),
+        fee_addr: None,
     };
 
     pub static ref DUMMY_VALIDATOR_FOLLOWER: ValidatorDesc = ValidatorDesc {
         id:  ValidatorId::try_from("c91763d7f14ac5c5ddfbcd012e0d2a61ab9bded3").expect("Failed to parse DUMMY_VALIDATOR_FOLLOWER id "),
         url: "http://localhost:8006".to_string(),
         fee: 100.into(),
+        fee_addr: None,
     };
 
     pub static ref DUMMY_CHANNEL: Channel = {

--- a/primitives/src/validator.rs
+++ b/primitives/src/validator.rs
@@ -28,7 +28,7 @@ impl ValidatorId {
     }
 
     pub fn to_hex_checksummed_string(&self) -> String {
-        eth_checksum::checksum(&format!("0x{}", hex::encode(self.0)))
+        eth_checksum::checksum(&format!("0x{}", self.to_hex_non_prefix_string()))
     }
 }
 
@@ -79,7 +79,7 @@ impl TryFrom<&String> for ValidatorId {
 
 impl fmt::Display for ValidatorId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", format!("0x{}", hex::encode(self.0)))
+        write!(f, "{}", format!("0x{}", self.to_hex_non_prefix_string()))
     }
 }
 

--- a/primitives/src/validator.rs
+++ b/primitives/src/validator.rs
@@ -87,6 +87,7 @@ impl fmt::Display for ValidatorId {
 #[serde(rename_all = "camelCase")]
 pub struct ValidatorDesc {
     pub id: ValidatorId,
+    pub fee_addr: Option<ValidatorId>,
     pub url: String,
     pub fee: BigNum,
 }

--- a/validator_worker/src/core/fees.rs
+++ b/validator_worker/src/core/fees.rs
@@ -76,8 +76,9 @@ fn distribute_fee<'a>(
         };
 
         if fee_rounded > 0.into() {
+            let addr = validator.fee_addr.as_ref().unwrap_or(&validator.id);
             let entry = balances
-                .entry(validator.id.to_string())
+                .entry(addr.to_string())
                 .or_insert_with(|| 0.into());
 
             *entry += &fee_rounded;

--- a/validator_worker/src/core/fees.rs
+++ b/validator_worker/src/core/fees.rs
@@ -77,9 +77,7 @@ fn distribute_fee<'a>(
 
         if fee_rounded > 0.into() {
             let addr = validator.fee_addr.as_ref().unwrap_or(&validator.id);
-            let entry = balances
-                .entry(addr.to_string())
-                .or_insert_with(|| 0.into());
+            let entry = balances.entry(addr.to_string()).or_insert_with(|| 0.into());
 
             *entry += &fee_rounded;
         }

--- a/validator_worker/src/sentry_interface.rs
+++ b/validator_worker/src/sentry_interface.rs
@@ -96,7 +96,7 @@ impl<T: Adapter + 'static> SentryApi<T> {
         let url = format!(
             "{}/validator-messages/{}/{}?limit=1",
             self.validator_url,
-            from.to_string(),
+            from.to_hex_checksummed_string(),
             message_type
         );
         let result = self


### PR DESCRIPTION
This implements `feeAddr` which was introduced here: https://github.com/AdExNetwork/adex-protocol/commit/6421206af9e3a19bf7e3b5b4a79e088fbe9d2781

Additionally, this fixes an issue which caused the JS tests to fail cause of this commit: c06efcd285cf04f9431ca5dbac0841c1b561efd8 which always sends ?validator=<checksummed addr>, while the tests expect it to be lowercase

The tests were modified to [use checksummed address](https://github.com/AdExNetwork/adex-validator/commit/51cdfdd203719a64ced079b0f17e36f06c4f37b9), but then it was discovered that `sentry_interface` uses lowercase... so that was corrected

**Our policy is that we use checksummed addresses for everything except balance trees, which is now documented [here](https://github.com/adexnetwork/adex-validator#address-convention)!**
