### PR TITLE
Validator worker: quick fixes

### DIFF
--- a/adapter/src/ethereum.rs
+++ b/adapter/src/ethereum.rs
@@ -377,10 +377,9 @@ pub fn ewt_sign(
 
     let payload_encoded =
         base64::encode_config(&serde_json::to_string(payload)?, base64::URL_SAFE_NO_PAD);
-    let message = Message::from_slice(&hash_message(&format!(
-        "{}.{}",
-        header_encoded, payload_encoded
-    ).as_bytes()));
+    let message = Message::from_slice(&hash_message(
+        &format!("{}.{}", header_encoded, payload_encoded).as_bytes(),
+    ));
     let signature: Signature = signer
         .sign(password, &message)
         .map_err(|_| map_error("sign message"))?
@@ -400,10 +399,9 @@ pub fn ewt_verify(
     payload_encoded: &str,
     token: &str,
 ) -> Result<VerifyPayload, Box<dyn Error>> {
-    let message = Message::from_slice(&hash_message(&format!(
-        "{}.{}",
-        header_encoded, payload_encoded
-    ).as_bytes()));
+    let message = Message::from_slice(&hash_message(
+        &format!("{}.{}", header_encoded, payload_encoded).as_bytes(),
+    ));
 
     let decoded_signature = base64::decode_config(&token, base64::URL_SAFE_NO_PAD)?;
     let signature = Signature::from_electrum(&decoded_signature);

--- a/adapter/src/ethereum.rs
+++ b/adapter/src/ethereum.rs
@@ -472,19 +472,19 @@ mod test {
 
         // Sign
         let expected_response =
-            "0xce654de0b3d14d63e1cb3181eee7a7a37ef4a06c9fabc204faf96f26357441b625b1be460fbe8f5278cc02aa88a5d0ac2f238e9e3b8e4893760d33bccf77e47f1b";
+            "0x625fd46f82c4cfd135ea6a8534e85dbf50beb157046dce59d2e97aacdf4e38381d1513c0e6f002b2f05c05458038b187754ff38cc0658dfc9ba854cccfb6e13e1b";
         let message = "2bdeafae53940669daa6f519373f686c";
         let response = eth_adapter.sign(message).expect("failed to sign message");
         assert_eq!(expected_response, response, "invalid signature");
 
         // Verify
         let signature =
-            "0xce654de0b3d14d63e1cb3181eee7a7a37ef4a06c9fabc204faf96f26357441b625b1be460fbe8f5278cc02aa88a5d0ac2f238e9e3b8e4893760d33bccf77e47f1b";
+            "0x9e07f12958ce7c5eb1362eb9461e4745dd9d74a42b921391393caea700bfbd6e1ad876a7d8f9202ef1fe6110dbfe87840c5676ca5c4fda9f3330694a1ac2a1fc1b";
         let verify = eth_adapter
             .verify(
-                &ValidatorId::try_from("2bDeAFAE53940669DaA6F519373f686c1f3d3393")
+                &ValidatorId::try_from("2892f6C41E0718eeeDd49D98D648C789668cA67d")
                     .expect("Failed to parse id"),
-                "2bdeafae53940669daa6f519373f686c",
+                "8bc45d8eb27f4c98cab35d17b0baecc2a263d6831ef0800f4c190cbfac6d20a3",
                 &signature,
             )
             .expect("Failed to verify signatures");

--- a/adapter/src/ethereum.rs
+++ b/adapter/src/ethereum.rs
@@ -130,7 +130,10 @@ impl Adapter for EthereumAdapter {
     }
 
     fn verify(&self, signer: &ValidatorId, state_root: &str, sig: &str) -> AdapterResult<bool> {
-        let decoded_signature = hex::decode(sig)
+        if !sig.starts_with("0x") {
+            return Err(AdapterError::Signature("not 0x prefixed hex".to_string()));
+        }
+        let decoded_signature = hex::decode(&sig[2..])
             .map_err(|_| AdapterError::Signature("invalid signature".to_string()))?;
         let address = Address::from_slice(signer.inner());
         let signature = Signature::from_electrum(&decoded_signature);
@@ -473,7 +476,7 @@ mod test {
 
         // Verify
         let signature =
-            "ce654de0b3d14d63e1cb3181eee7a7a37ef4a06c9fabc204faf96f26357441b625b1be460fbe8f5278cc02aa88a5d0ac2f238e9e3b8e4893760d33bccf77e47f1b";
+            "0xce654de0b3d14d63e1cb3181eee7a7a37ef4a06c9fabc204faf96f26357441b625b1be460fbe8f5278cc02aa88a5d0ac2f238e9e3b8e4893760d33bccf77e47f1b";
         let verify = eth_adapter
             .verify(
                 &ValidatorId::try_from("2bDeAFAE53940669DaA6F519373f686c1f3d3393")

--- a/validator_worker/src/main.rs
+++ b/validator_worker/src/main.rs
@@ -198,13 +198,17 @@ async fn validator_tick<A: Adapter + 'static>(
 
     match channel.spec.validators.find(&whoami) {
         SpecValidator::Leader(_) => {
-            if let Err(e) = timeout(duration, leader::tick(&sentry)).await {
-                return Err(ValidatorWorkerError::Failed(e.to_string()));
+            match timeout(duration, leader::tick(&sentry)).await {
+                Err(e) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+                Ok(Err(e)) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+                _ => ()
             }
         }
         SpecValidator::Follower(_) => {
-            if let Err(e) = timeout(duration, follower::tick(&sentry)).await {
-                return Err(ValidatorWorkerError::Failed(e.to_string()));
+            match timeout(duration, follower::tick(&sentry)).await {
+                Err(e) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+                Ok(Err(e)) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+                _ => ()
             }
         }
         SpecValidator::None => {

--- a/validator_worker/src/main.rs
+++ b/validator_worker/src/main.rs
@@ -197,20 +197,16 @@ async fn validator_tick<A: Adapter + 'static>(
     let duration = Duration::from_millis(config.validator_tick_timeout as u64);
 
     match channel.spec.validators.find(&whoami) {
-        SpecValidator::Leader(_) => {
-            match timeout(duration, leader::tick(&sentry)).await {
-                Err(e) => return Err(ValidatorWorkerError::Failed(e.to_string())),
-                Ok(Err(e)) => return Err(ValidatorWorkerError::Failed(e.to_string())),
-                _ => ()
-            }
-        }
-        SpecValidator::Follower(_) => {
-            match timeout(duration, follower::tick(&sentry)).await {
-                Err(e) => return Err(ValidatorWorkerError::Failed(e.to_string())),
-                Ok(Err(e)) => return Err(ValidatorWorkerError::Failed(e.to_string())),
-                _ => ()
-            }
-        }
+        SpecValidator::Leader(_) => match timeout(duration, leader::tick(&sentry)).await {
+            Err(e) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+            Ok(Err(e)) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+            _ => (),
+        },
+        SpecValidator::Follower(_) => match timeout(duration, follower::tick(&sentry)).await {
+            Err(e) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+            Ok(Err(e)) => return Err(ValidatorWorkerError::Failed(e.to_string())),
+            _ => (),
+        },
         SpecValidator::None => {
             return Err(ValidatorWorkerError::Failed(
                 "validatorTick: processing a channel where we are not validating".to_string(),


### PR DESCRIPTION
- handle tick errors properly
- ethereum adapter: interpret the state_root as a hex string rather than a string
- ethereum adapter: signature is always 0x prefixed