### PR TITLE
MarketChannel changes

### DIFF
--- a/adview-manager/src/lib.rs
+++ b/adview-manager/src/lib.rs
@@ -1,8 +1,8 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
 
-use adex_primitives::market_channel::{MarketChannel, MarketStatusType};
-use adex_primitives::{AdUnit, BigNum, SpecValidators, TargetingTag};
+use adex_primitives::market::{Campaign, StatusType};
+use adex_primitives::{ChannelId, AdUnit, BigNum, SpecValidators, TargetingTag};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
@@ -18,7 +18,7 @@ pub struct AdViewManagerOptions {
     #[serde(rename = "marketURL")]
     pub market_url: String,
     /// Defaulted
-    pub accepted_states: Vec<MarketStatusType>,
+    pub accepted_states: Vec<StatusType>,
     /// Defaulted
     pub min_per_impression: BigNum,
     /// Defaulted
@@ -51,7 +51,7 @@ impl AdViewManagerOptions {
 #[derive(Debug)]
 pub struct UnitByPrice {
     pub unit: AdUnit,
-    pub channel_id: String,
+    pub channel_id: ChannelId,
     pub validators: SpecValidators,
     pub min_targeting_score: MinTargetingScore,
     pub min_per_impression: BigNum,
@@ -60,7 +60,7 @@ pub struct UnitByPrice {
 #[derive(Debug)]
 pub struct Unit {
     pub unit: AdUnit,
-    pub channel_id: String,
+    pub channel_id: ChannelId,
     pub validators: SpecValidators,
     pub min_targeting_score: MinTargetingScore,
     pub min_per_impression: BigNum,
@@ -80,24 +80,26 @@ impl Unit {
     }
 }
 
-pub fn apply_selection(campaigns: &[MarketChannel], options: &AdViewManagerOptions) -> Vec<Unit> {
+pub fn apply_selection(campaigns: &[Campaign], options: &AdViewManagerOptions) -> Vec<Unit> {
     let eligible = campaigns.iter().filter(|campaign| {
         options
             .accepted_states
             .contains(&campaign.status.status_type)
             && campaign
+                .channel
                 .spec
                 .active_from
                 .map(|datetime| datetime < Utc::now())
                 .unwrap_or(true)
-            && campaign.deposit_asset == options.whitelisted_token
-            && campaign.spec.min_per_impression >= options.min_per_impression
+            && campaign.channel.deposit_asset == options.whitelisted_token
+            && campaign.channel.spec.min_per_impression >= options.min_per_impression
     });
 
     let mut units: Vec<UnitByPrice> = eligible
         // filter ad_units by whitelisted type, map then to UnitByPrice and flat_map them for each campaing
         .flat_map(|campaign| {
             campaign
+                .channel
                 .spec
                 .ad_units
                 .iter()
@@ -113,13 +115,13 @@ pub fn apply_selection(campaigns: &[MarketChannel], options: &AdViewManagerOptio
                 })
                 .map(move |ad_unit| UnitByPrice {
                     unit: ad_unit.clone(),
-                    channel_id: campaign.id.clone(),
-                    validators: campaign.spec.validators.clone(),
+                    channel_id: campaign.channel.id,
+                    validators: campaign.channel.spec.validators.clone(),
                     min_targeting_score: ad_unit
                         .min_targeting_score
-                        .or(campaign.spec.min_targeting_score)
+                        .or(campaign.channel.spec.min_targeting_score)
                         .unwrap_or_else(|| 0.into()),
-                    min_per_impression: campaign.spec.min_per_impression.clone(),
+                    min_per_impression: campaign.channel.spec.min_per_impression.clone(),
                 })
         })
         .collect();
@@ -223,7 +225,7 @@ fn video_html(
 pub fn get_html(
     options: &AdViewManagerOptions,
     ad_unit: AdUnit,
-    channel_id: &str,
+    channel_id: ChannelId,
     validators: &SpecValidators,
 ) -> String {
     let ev_body = EventBody {
@@ -267,19 +269,19 @@ fn get_unit_html(
     let adex_icon = "<a href=\"https://www.adex.network\" target=\"_blank\" rel=\"noopener noreferrer\"
             style=\"position: absolute; top: 0; right: 0;\"
         >
-		<svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" x=\"0px\" y=\"0px\" width=\"18px\"
-			height=\"18px\" viewBox=\"0 0 18 18\" style=\"enable-background:new 0 0 18 18;\" xml:space=\"preserve\">
-			<style type=\"text/css\">
-				.st0{fill:#FFFFFF;}
-				.st1{fill:#1B75BC;}
-			</style>
-			<defs>
-			</defs>
-			<rect class=\"st0\" width=\"18\" height=\"18\"/>
-			<path class=\"st1\" d=\"M14,12.1L10.9,9L14,5.9L12.1,4L9,7.1L5.9,4L4,5.9L7.1,9L4,12.1L5.9,14L9,10.9l3.1,3.1L14,12.1z M7.9,2L6.4,3.5
-				L7.9,5L9,3.9L10.1,5l1.5-1.5L10,1.9l-1-1L7.9,2 M7.9,16l-1.5-1.5L7.9,13L9,14.1l1.1-1.1l1.5,1.5L10,16.1l-1,1L7.9,16\"/>
-   			</svg>
-		</a>";
+        <svg version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" x=\"0px\" y=\"0px\" width=\"18px\"
+            height=\"18px\" viewBox=\"0 0 18 18\" style=\"enable-background:new 0 0 18 18;\" xml:space=\"preserve\">
+            <style type=\"text/css\">
+                .st0{fill:#FFFFFF;}
+                .st1{fill:#1B75BC;}
+            </style>
+            <defs>
+            </defs>
+            <rect class=\"st0\" width=\"18\" height=\"18\"/>
+            <path class=\"st1\" d=\"M14,12.1L10.9,9L14,5.9L12.1,4L9,7.1L5.9,4L4,5.9L7.1,9L4,12.1L5.9,14L9,10.9l3.1,3.1L14,12.1z M7.9,2L6.4,3.5
+                L7.9,5L9,3.9L10.1,5l1.5-1.5L10,1.9l-1-1L7.9,2 M7.9,16l-1.5-1.5L7.9,13L9,14.1l1.1-1.1l1.5,1.5L10,16.1l-1,1L7.9,16\"/>
+               </svg>
+        </a>";
 
     let result = format!("
         <div style=\"position: relative; overflow: hidden; {size}\">

--- a/adview-manager/src/lib.rs
+++ b/adview-manager/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(clippy::all)]
 
 use adex_primitives::market::{Campaign, StatusType};
-use adex_primitives::{ChannelId, AdUnit, BigNum, SpecValidators, TargetingTag};
+use adex_primitives::{AdUnit, BigNum, ChannelId, SpecValidators, TargetingTag};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 

--- a/primitives/src/balances_map.rs
+++ b/primitives/src/balances_map.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::{BigNum, ValidatorId};
-use std::collections::btree_map::{Entry, Iter, Values};
+use std::collections::btree_map::{Entry, Iter, IntoIter, Values};
 
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;
@@ -47,6 +47,15 @@ impl FromIterator<(ValidatorId, BigNum)> for BalancesMap {
         let btree_map: BTreeMap<ValidatorId, BigNum> = iter.into_iter().collect();
 
         BalancesMap(btree_map)
+    }
+}
+
+impl IntoIterator for BalancesMap {
+    type Item = (ValidatorId, BigNum);
+    type IntoIter = IntoIter<ValidatorId, BigNum>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/primitives/src/balances_map.rs
+++ b/primitives/src/balances_map.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::{BigNum, ValidatorId};
-use std::collections::btree_map::{Entry, Iter, IntoIter, Values};
+use std::collections::btree_map::{Entry, IntoIter, Iter, Values};
 
 use serde::{Deserialize, Serialize};
 use std::iter::FromIterator;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -11,7 +11,7 @@ pub mod channel;
 pub mod channel_validator;
 pub mod config;
 pub mod event_submission;
-pub mod market_channel;
+pub mod market;
 pub mod merkle_tree;
 pub mod sentry;
 pub mod targeting_tag;

--- a/primitives/src/market.rs
+++ b/primitives/src/market.rs
@@ -35,7 +35,7 @@ impl fmt::Display for StatusType {
 pub struct Status {
     #[serde(rename = "name")]
     pub status_type: StatusType,
-    pub usd_estimate: f32,
+    pub usd_estimate: Option<f32>,
     #[serde(rename = "lastApprovedBalances")]
     pub balances: BalancesMap,
     #[serde(with = "ts_milliseconds")]

--- a/primitives/src/market.rs
+++ b/primitives/src/market.rs
@@ -8,15 +8,19 @@ use crate::{BalancesMap, BigNum, Channel};
 // Data structs specific to the market
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum StatusType {
-    Initializing,
-    Ready,
     Active,
+    Ready,
+    Pending,
+    Initializing,
+    Waiting,
     Offline,
     Disconnected,
     Unhealthy,
-    Withdraw,
+    Invalid,
     Expired,
+    /// also called "Closed"
     Exhausted,
+    Withdraw,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/primitives/src/market.rs
+++ b/primitives/src/market.rs
@@ -40,6 +40,7 @@ impl Status {
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Campaign {
+    #[serde(flatten)]
     pub channel: Channel,
     pub status: Status,
 }

--- a/primitives/src/market.rs
+++ b/primitives/src/market.rs
@@ -1,7 +1,8 @@
 use chrono::serde::ts_milliseconds;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use chrono::{DateTime, Utc};
+use std::fmt;
 
 use crate::{BalancesMap, BigNum, Channel};
 
@@ -21,6 +22,12 @@ pub enum StatusType {
     /// also called "Closed"
     Exhausted,
     Withdraw,
+}
+
+impl fmt::Display for StatusType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/primitives/src/market.rs
+++ b/primitives/src/market.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use chrono::{DateTime, Utc};
 
-use crate::{BigNum, Channel, BalancesMap};
+use crate::{BalancesMap, BigNum, Channel};
 
 // Data structs specific to the market
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/primitives/src/market.rs
+++ b/primitives/src/market.rs
@@ -1,14 +1,13 @@
 use chrono::serde::ts_milliseconds;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 
-use crate::{BigNum, ChannelSpec};
+use crate::{BigNum, Channel, BalancesMap};
 
 // Data structs specific to the market
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MarketStatusType {
+pub enum StatusType {
     Initializing,
     Ready,
     Active,
@@ -22,17 +21,17 @@ pub enum MarketStatusType {
 
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct MarketStatus {
+pub struct Status {
     #[serde(rename = "name")]
-    pub status_type: MarketStatusType,
+    pub status_type: StatusType,
     pub usd_estimate: f32,
     #[serde(rename = "lastApprovedBalances")]
-    pub balances: HashMap<String, BigNum>,
+    pub balances: BalancesMap,
     #[serde(with = "ts_milliseconds")]
     pub last_checked: DateTime<Utc>,
 }
 
-impl MarketStatus {
+impl Status {
     pub fn balances_sum(&self) -> BigNum {
         self.balances.values().sum()
     }
@@ -40,11 +39,7 @@ impl MarketStatus {
 
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct MarketChannel {
-    pub id: String,
-    pub creator: String,
-    pub deposit_asset: String,
-    pub deposit_amount: BigNum,
-    pub status: MarketStatus,
-    pub spec: ChannelSpec,
+pub struct Campaign {
+    pub channel: Channel,
+    pub status: Status,
 }

--- a/primitives/src/sentry.rs
+++ b/primitives/src/sentry.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LastApproved {
     /// NewState can be None if the channel is brand new
@@ -15,21 +15,21 @@ pub struct LastApproved {
     pub approve_state: Option<ApproveStateValidatorMessage>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct NewStateValidatorMessage {
     pub from: ValidatorId,
     pub received: DateTime<Utc>,
     pub msg: MessageTypes,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ApproveStateValidatorMessage {
     pub from: ValidatorId,
     pub received: DateTime<Utc>,
     pub msg: MessageTypes,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct HeartbeatValidatorMessage {
     pub from: ValidatorId,
     pub received: DateTime<Utc>,
@@ -129,7 +129,7 @@ pub struct ChannelListResponse {
     pub total_pages: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LastApprovedResponse {
     pub last_approved: Option<LastApproved>,

--- a/primitives/src/validator.rs
+++ b/primitives/src/validator.rs
@@ -137,7 +137,7 @@ pub struct ValidatorDesc {
 
 // Validator Message Types
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Accounting {
     #[serde(rename = "lastEvAggr")]
@@ -146,7 +146,7 @@ pub struct Accounting {
     pub balances: BalancesMap,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ApproveState {
     pub state_root: String,
@@ -154,7 +154,7 @@ pub struct ApproveState {
     pub is_healthy: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NewState {
     pub state_root: String,
@@ -162,7 +162,7 @@ pub struct NewState {
     pub balances: BalancesMap,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct RejectState {
     pub reason: String,
@@ -172,7 +172,7 @@ pub struct RejectState {
     pub timestamp: Option<DateTime<Utc>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Heartbeat {
     pub signature: String,
@@ -190,7 +190,7 @@ impl Heartbeat {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
 pub enum MessageTypes {
     ApproveState(ApproveState),

--- a/sentry/src/lib.rs
+++ b/sentry/src/lib.rs
@@ -136,8 +136,7 @@ impl<A: Adapter + 'static> Application<A> {
             }
         };
 
-        let path = req.uri().path().to_string();
-        let mut response = match (path.as_ref(), req.method()) {
+        let mut response = match (req.uri().path(), req.method()) {
             ("/cfg", &Method::GET) => config(req, &self).await,
             ("/channel", &Method::POST) => create_channel(req, &self).await,
             ("/channel/list", &Method::GET) => channel_list(req, &self).await,

--- a/sentry/src/main.rs
+++ b/sentry/src/main.rs
@@ -127,7 +127,7 @@ async fn run<A: Adapter + 'static>(app: Application<A>, port: u16) {
     let logger = app.logger.clone();
     info!(&logger, "Listening on port {}!", port);
 
-    let make_service = make_service_fn(move |_| {
+    let make_service = make_service_fn(|_| {
         let server = app.clone();
         async move {
             Ok::<_, Error>(service_fn(move |req| {


### PR DESCRIPTION
In order to reuse the Market Campaign as part of AdExNetwork/adex-supermarket#1 we need to clean-up an update the `adview-manager` crate and clean up the naming a bit to make it consistent.

- [x] Clean up Market Campaign
- [x] Update `adview-manager` crate
- [x] Make naming more consistent (i.e. `primitives::market::Campaign`)