### PR TITLE
fix: only creator should close channel

### DIFF
--- a/sentry/src/access.rs
+++ b/sentry/src/access.rs
@@ -72,7 +72,7 @@ pub async fn check_access(
     }
 
     // Only the creator can send a CLOSE
-    if is_creator && events.iter().any(is_close_event) {
+    if !is_creator && events.iter().any(is_close_event) {
         return Err(Error::OnlyCreatorCanCloseChannel);
     }
 


### PR DESCRIPTION
Fix only creator should be able to send close event