### PR TITLE
Issue #296 AIP#31 Targeting eval()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-hex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -34,7 +34,7 @@ dependencies = [
  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -676,7 +676,7 @@ dependencies = [
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -776,7 +776,7 @@ dependencies = [
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1367,7 +1367,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1557,7 +1557,7 @@ dependencies = [
  "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2116,7 +2116,7 @@ dependencies = [
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-protocol 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2156,7 +2156,7 @@ dependencies = [
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-hex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_millis 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2491,7 +2491,7 @@ dependencies = [
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pin-project-lite 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2707,7 +2707,7 @@ dependencies = [
  "redis 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.48"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3496,7 +3496,7 @@ dependencies = [
  "primitives 0.1.0",
  "reqwest 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3568,7 +3568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3654,7 +3654,7 @@ dependencies = [
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4054,7 +4054,7 @@ dependencies = [
 "checksum serde 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 "checksum serde-hex 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
 "checksum serde_derive 1.0.105 (registry+https://github.com/rust-lang/crates.io-index)" = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
-"checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
+"checksum serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 "checksum serde_millis 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e2dc780ca5ee2c369d1d01d100270203c4ff923d2a4264812d723766434d00"
 "checksum serde_urlencoded 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"

--- a/primitives/src/big_num.rs
+++ b/primitives/src/big_num.rs
@@ -197,6 +197,14 @@ impl TryFrom<&str> for BigNum {
     }
 }
 
+impl FromStr for BigNum {
+    type Err = super::DomainError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        BigNum::try_from(s)
+    }
+}
+
 impl ToString for BigNum {
     fn to_string(&self) -> String {
         self.0.to_str_radix(10)

--- a/primitives/src/channel.rs
+++ b/primitives/src/channel.rs
@@ -102,6 +102,22 @@ pub struct PricingBounds {
     pub click: Option<Pricing>,
 }
 
+impl PricingBounds {
+    pub fn to_vec(&self) -> Vec<(&str, Pricing)> {
+        let mut vec = Vec::new();
+
+        if let Some(pricing) = self.impression.as_ref() {
+            vec.push(("IMPRESSION", pricing.clone()));
+        }
+
+        if let Some(pricing) = self.click.as_ref() {
+            vec.push(("CLICK", pricing.clone()))
+        }
+
+        vec
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelSpec {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -14,6 +14,7 @@ pub mod event_submission;
 pub mod market;
 pub mod merkle_tree;
 pub mod sentry;
+pub mod targeting;
 pub mod targeting_tag;
 pub mod util {
     pub mod tests {

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -198,4 +198,29 @@ mod test {
 
         assert_eq!(Value::BigNum(BigNum::from(50)), global_campaign_budget);
     }
+
+    #[test]
+    fn test_output_from_channel() {
+        use crate::channel::{Pricing, PricingBounds};
+        use crate::util::tests::prep_db::DUMMY_CHANNEL;
+
+        let mut channel = DUMMY_CHANNEL.clone();
+        channel.spec.pricing_bounds = Some(PricingBounds {
+            impression: Some(Pricing {
+                min: 1_000.into(),
+                max: 2_000.into(),
+            }),
+            click: Some(Pricing {
+                min: 3_000.into(),
+                max: 4_000.into(),
+            }),
+        });
+
+        let output = Output::from(&channel);
+
+        assert_eq!(true, output.show);
+        assert_eq!(1.0, output.boost);
+        assert_eq!(Some(&BigNum::from(1_000)), output.price.get("IMPRESSION"));
+        assert_eq!(Some(&BigNum::from(3_000)), output.price.get("CLICK"));
+    }
 }

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -1,60 +1,86 @@
 use crate::BigNum;
+use serde::{Deserialize, Serialize};
 use serde_json::{
     value::{Map as SerdeMap, Value as SerdeValue},
     Number,
 };
 use std::convert::TryFrom;
+use std::fmt;
 
 pub type Map = SerdeMap<String, SerdeValue>;
-pub type Rule = SerdeValue;
 
+#[derive(Debug)]
 pub enum Error {
     TypeError,
     UnknownVariable,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EvalValue {
-    Null,
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::TypeError => write!(f, "TypeError: Wrong type"),
+            Error::UnknownVariable => write!(f, "UnknownVariable: Unknown varialbe passed"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "SerdeValue")]
+pub enum Value {
     Bool(bool),
     Number(Number),
     String(String),
-    Array(Vec<EvalValue>),
+    Array(Vec<Value>),
     BigNum(BigNum),
 }
 
-impl TryFrom<SerdeValue> for EvalValue {
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Rule {
+    Function(Function),
+    Value(Value),
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum Function {
+    If(Box<Rule>, Box<Rule>),
+    And(Box<Rule>, Box<Rule>),
+    Intersects(Box<Rule>, Box<Rule>),
+    Get(String),
+}
+
+impl TryFrom<SerdeValue> for Value {
     type Error = Error;
 
     fn try_from(serde_value: SerdeValue) -> Result<Self, Self::Error> {
         match serde_value {
-            SerdeValue::Null => Ok(Self::Null),
             SerdeValue::Bool(bool) => Ok(Self::Bool(bool)),
             SerdeValue::Number(number) => Ok(Self::Number(number)),
             SerdeValue::String(string) => Ok(Self::String(string)),
             SerdeValue::Array(serde_array) => {
                 let array = serde_array
                     .into_iter()
-                    .map(EvalValue::try_from)
+                    .map(Value::try_from)
                     .collect::<Result<_, _>>()?;
                 Ok(Self::Array(array))
             }
-            SerdeValue::Object(_) => Err(Error::TypeError),
+            SerdeValue::Object(_) | SerdeValue::Null => Err(Error::TypeError),
         }
     }
 }
 
-impl EvalValue {
-    pub fn try_bool(&self) -> Result<bool, Error> {
-        match *self {
+impl Value {
+    pub fn try_bool(self) -> Result<bool, Error> {
+        match self {
             Self::Bool(b) => Ok(b),
             _ => Err(Error::TypeError),
         }
     }
 
-    pub fn try_array(&self) -> Result<Vec<EvalValue>, Error> {
-        match *self {
-            Self::Array(ref array) => Ok(array.to_vec()),
+    pub fn try_array(self) -> Result<Vec<Value>, Error> {
+        match self {
+            Self::Array(array) => Ok(array),
             _ => Err(Error::TypeError),
         }
     }
@@ -69,39 +95,124 @@ impl EvalValue {
 ///     - Array
 /// - Mutates output
 /// - Throws an error
-// TODO: Move to own module!
-pub fn eval(input: &Map, output: &mut Map, rule: &Rule) -> Result<EvalValue, Error> {
-    let rule = match rule {
-        Rule::Null => return Err(Error::TypeError),
-        Rule::Object(map) => map,
-        value => return EvalValue::try_from(value.to_owned()),
+pub fn eval(input: &Map, output: &mut Map, rule: &Rule) -> Result<Option<Value>, Error> {
+    let function = match rule {
+        Rule::Value(value) => return Ok(Some(value.clone())),
+        Rule::Function(function) => function,
     };
 
     // basic operators
-    if let Some(SerdeValue::Array(array)) = rule.get("if") {
-        let (first_rule, second_rule) = match array.get(0..=1) {
-            Some(&[ref first_rule, ref second_rule]) => (first_rule, second_rule),
-            _ => return Err(Error::TypeError),
-        };
+    let value = match function {
+        Function::If(first_rule, second_rule) => {
+            let eval_if = eval(input, output, first_rule)?
+                .ok_or(Error::TypeError)?
+                .try_bool()?;
 
-        let eval_if = eval(input, output, first_rule)?.try_bool()?;
-
-        if eval_if {
-            let bool = eval(input, output, second_rule)?.try_bool()?;
-            return Ok(EvalValue::Bool(bool));
+            if eval_if {
+                let bool = eval(input, output, second_rule)?
+                    .ok_or(Error::TypeError)?
+                    .try_bool()?;
+                Some(Value::Bool(bool))
+            } else {
+                None
+            }
         }
-    } else if let Some(SerdeValue::Array(array)) = rule.get("intersects") {
-        // lists
-        let (first_rule, second_rule) = match array.get(0..=1) {
-            Some(&[ref first_rule, ref second_rule]) => (first_rule, second_rule),
-            _ => return Err(Error::TypeError),
-        };
+        Function::And(first_rule, second_rule) => {
+            let a = eval(input, output, first_rule)?
+                .ok_or(Error::TypeError)?
+                .try_bool()?;
+            let b = eval(input, output, second_rule)?
+                .ok_or(Error::TypeError)?
+                .try_bool()?;
 
-        let a = eval(input, output, first_rule)?.try_array()?;
-        let b = eval(input, output, second_rule)?.try_array()?;
+            Some(Value::Bool(a && b))
+        }
+        Function::Intersects(first_rule, second_rule) => {
+            let a = eval(input, output, first_rule)?
+                .ok_or(Error::TypeError)?
+                .try_array()?;
+            let b = eval(input, output, second_rule)?
+                .ok_or(Error::TypeError)?
+                .try_array()?;
 
-        return Ok(EvalValue::Bool(a.iter().any(|x| b.contains(x))));
+            Some(Value::Bool(a.iter().any(|x| b.contains(x))))
+        }
+        Function::Get(key) => {
+            let input_value = input.get(key).ok_or(Error::UnknownVariable)?;
+
+            Some(Value::try_from(input_value.clone())?)
+        }
+    };
+
+    Ok(value)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn deserialzes_intersects_rule() {
+        let json = r#"{"intersects": [{ "get": "adSlot.categories" }, ["News", "Bitcoin"]]}"#;
+
+        let parsed_rule = serde_json::from_str::<Rule>(json).expect("Should deserialize");
+
+        let mut expected_map = SerdeMap::new();
+        expected_map.insert(
+            "get".to_string(),
+            SerdeValue::String("adSlot.categories".to_string()),
+        );
+
+        let expected = Rule::Function(Function::Intersects(
+            Box::new(Rule::Function(Function::Get(
+                "adSlot.categories".to_string(),
+            ))),
+            Box::new(Rule::Value(Value::Array(vec![
+                Value::String("News".to_string()),
+                Value::String("Bitcoin".to_string()),
+            ]))),
+        ));
+
+        assert_eq!(expected, parsed_rule)
     }
 
-    Ok(EvalValue::Null)
+    /// ```json
+    /// {
+    ///   "intersects": [
+    ///     {
+    ///       "get": "publisherId"
+    ///     },
+    ///     [
+    ///       "0xd5860D6196A4900bf46617cEf088ee6E6b61C9d6",
+    ///       "0xd5860D6196A4900bf46617cEf088ee6E6b61C9d3"
+    ///     ]
+    ///   ]
+    /// }
+    /// ```
+    #[test]
+    fn test_simple_intersect_eval() {
+        let input: Map = vec![(
+            "publisherId".to_string(),
+            SerdeValue::Array(vec![SerdeValue::String(
+                "0xd5860D6196A4900bf46617cEf088ee6E6b61C9d6".to_string(),
+            )]),
+        )]
+        .into_iter()
+        .collect();
+        let mut output = SerdeMap::new();
+
+        let publishers = vec![
+            Value::String("0xd5860D6196A4900bf46617cEf088ee6E6b61C9d6".to_string()),
+            Value::String("0xd5860D6196A4900bf46617cEf088ee6E6b61C9d3".to_string()),
+        ];
+
+        let rules = Rule::Function(Function::Intersects(
+            Box::new(Rule::Function(Function::Get("publisherId".to_string()))),
+            Box::new(Rule::Value(Value::Array(publishers))),
+        ));
+
+        let result = eval(&input, &mut output, &rules).expect("Should eval rules");
+
+        assert_eq!(Value::Bool(true), result.expect("Sould be Some!"));
+    }
 }

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -1,0 +1,107 @@
+use crate::BigNum;
+use serde_json::{
+    value::{Map as SerdeMap, Value as SerdeValue},
+    Number,
+};
+use std::convert::TryFrom;
+
+pub type Map = SerdeMap<String, SerdeValue>;
+pub type Rule = SerdeValue;
+
+pub enum Error {
+    TypeError,
+    UnknownVariable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EvalValue {
+    Null,
+    Bool(bool),
+    Number(Number),
+    String(String),
+    Array(Vec<EvalValue>),
+    BigNum(BigNum),
+}
+
+impl TryFrom<SerdeValue> for EvalValue {
+    type Error = Error;
+
+    fn try_from(serde_value: SerdeValue) -> Result<Self, Self::Error> {
+        match serde_value {
+            SerdeValue::Null => Ok(Self::Null),
+            SerdeValue::Bool(bool) => Ok(Self::Bool(bool)),
+            SerdeValue::Number(number) => Ok(Self::Number(number)),
+            SerdeValue::String(string) => Ok(Self::String(string)),
+            SerdeValue::Array(serde_array) => {
+                let array = serde_array
+                    .into_iter()
+                    .map(EvalValue::try_from)
+                    .collect::<Result<_, _>>()?;
+                Ok(Self::Array(array))
+            }
+            SerdeValue::Object(_) => Err(Error::TypeError),
+        }
+    }
+}
+
+impl EvalValue {
+    pub fn try_bool(&self) -> Result<bool, Error> {
+        match *self {
+            Self::Bool(b) => Ok(b),
+            _ => Err(Error::TypeError),
+        }
+    }
+
+    pub fn try_array(&self) -> Result<Vec<EvalValue>, Error> {
+        match *self {
+            Self::Array(ref array) => Ok(array.to_vec()),
+            _ => Err(Error::TypeError),
+        }
+    }
+}
+
+/// Evaluates a Rule to be applied and has 3 outcomes:
+/// - Does nothing
+///     Rules returned directly:
+///     - Bool
+///     - Number
+///     - String
+///     - Array
+/// - Mutates output
+/// - Throws an error
+// TODO: Move to own module!
+pub fn eval(input: &Map, output: &mut Map, rule: &Rule) -> Result<EvalValue, Error> {
+    let rule = match rule {
+        Rule::Null => return Err(Error::TypeError),
+        Rule::Object(map) => map,
+        value => return EvalValue::try_from(value.to_owned()),
+    };
+
+    // basic operators
+    if let Some(SerdeValue::Array(array)) = rule.get("if") {
+        let (first_rule, second_rule) = match array.get(0..=1) {
+            Some(&[ref first_rule, ref second_rule]) => (first_rule, second_rule),
+            _ => return Err(Error::TypeError),
+        };
+
+        let eval_if = eval(input, output, first_rule)?.try_bool()?;
+
+        if eval_if {
+            let bool = eval(input, output, second_rule)?.try_bool()?;
+            return Ok(EvalValue::Bool(bool));
+        }
+    } else if let Some(SerdeValue::Array(array)) = rule.get("intersects") {
+        // lists
+        let (first_rule, second_rule) = match array.get(0..=1) {
+            Some(&[ref first_rule, ref second_rule]) => (first_rule, second_rule),
+            _ => return Err(Error::TypeError),
+        };
+
+        let a = eval(input, output, first_rule)?.try_array()?;
+        let b = eval(input, output, second_rule)?.try_array()?;
+
+        return Ok(EvalValue::Bool(a.iter().any(|x| b.contains(x))));
+    }
+
+    Ok(EvalValue::Null)
+}

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -1,24 +1,10 @@
 use crate::BigNum;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, convert::TryFrom};
+use std::collections::HashMap;
 
 pub use eval::*;
 
 mod eval;
-
-pub trait TryGet: Serialize {
-    const PATTERN: &'static str = ".";
-
-    fn try_get(&self, key: &str) -> Result<Value, Error> {
-        let serde_value = serde_json::json!(self);
-        let pointer = format!("/{pointer}", pointer = key.replace(Self::PATTERN, "/"));
-
-        match serde_value.pointer(&pointer) {
-            Some(serde_value) => Value::try_from(serde_value.clone()),
-            None => Err(Error::UnknownVariable),
-        }
-    }
-}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(Default))]
@@ -71,7 +57,9 @@ impl Input {
             )),
             "secondsSinceEpoch" => Ok(Value::Number(self.global.seconds_since_epoch.into())),
             "userAgentOS" => Ok(Value::String(self.global.user_agent_os.clone())),
-            "userAgentBrowserFamily" => Ok(Value::String(self.global.user_agent_browser_family.clone())),
+            "userAgentBrowserFamily" => {
+                Ok(Value::String(self.global.user_agent_browser_family.clone()))
+            }
             "adSlot.categories" => self
                 .ad_slot
                 .as_ref()
@@ -93,8 +81,8 @@ impl Input {
                 let ad_slot = self.ad_slot.as_ref().ok_or(Error::UnknownVariable)?;
 
                 match serde_json::Number::from_f64(ad_slot.alexa_rank) {
-                        Some(number) => Ok(Value::Number(number)),
-                        None => Err(Error::TypeError)
+                    Some(number) => Ok(Value::Number(number)),
+                    None => Err(Error::TypeError),
                 }
             }
             _unknown_field => Err(Error::UnknownVariable),

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -1,150 +1,116 @@
 use crate::BigNum;
 use serde::{Deserialize, Serialize};
-use serde_json::{
-    value::{Map as SerdeMap, Value as SerdeValue},
-    Number,
-};
-use std::convert::TryFrom;
-use std::fmt;
+use std::{collections::HashMap, convert::TryFrom};
 
-pub type Map = SerdeMap<String, SerdeValue>;
+pub use eval::*;
 
-#[derive(Debug)]
-pub enum Error {
-    TypeError,
-    UnknownVariable,
+mod eval;
+
+pub trait TryGet {
+    const PATTERN: &'static str;
+
+    fn try_get(&self, key: &str) -> Result<Value, Error>;
 }
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::TypeError => write!(f, "TypeError: Wrong type"),
-            Error::UnknownVariable => write!(f, "UnknownVariable: Unknown varialbe passed"),
+impl<T: Serialize> TryGet for T {
+    const PATTERN: &'static str = ".";
+
+    fn try_get(&self, key: &str) -> Result<Value, Error> {
+        let mut splitn = key.splitn(2, '.');
+
+        let (field, remaining_key) = (splitn.next(), splitn.next());
+        let serde_value = serde_json::json!(self);
+
+        // filter empty string
+        let field = field.filter(|s| !s.is_empty());
+        let remaining_key = remaining_key.filter(|s| !s.is_empty());
+
+        // TODO: Check what type of error we should return in each case
+        match (field, remaining_key, serde_value) {
+            (Some(field), remaining_key, serde_json::Value::Object(map)) => {
+                match map.get(field) {
+                    Some(serde_value) => serde_value.try_get(remaining_key.unwrap_or_default()),
+                    None => Err(Error::TypeError),
+                }
+            },
+            (None, None, serde_value) => Value::try_from(serde_value.clone()),
+            // if we have any other field or remaining_key, it's iligal:
+            // i.e. `first.second` for values that are not map
+            _ => Err(Error::UnknownVariable),
         }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(try_from = "SerdeValue")]
-pub enum Value {
-    Bool(bool),
-    Number(Number),
-    String(String),
-    Array(Vec<Value>),
-    BigNum(BigNum),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum Rule {
-    Function(Function),
-    Value(Value),
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Default))]
 #[serde(rename_all = "camelCase")]
-pub enum Function {
-    If(Box<Rule>, Box<Rule>),
-    And(Box<Rule>, Box<Rule>),
-    Intersects(Box<Rule>, Box<Rule>),
-    Get(String),
+pub struct Input {
+    /// AdView scope, accessible only on the AdView
+    #[serde(default)]
+    pub ad_view: Option<AdView>,
+    /// Global scope, accessible everywhere
+    #[serde(flatten)]
+    pub global: Global,
+    /// adSlot scope, accessible on Supermarket and AdView
+    #[serde(default)]
+    pub ad_slot: Option<AdSlot>,
 }
 
-impl TryFrom<SerdeValue> for Value {
-    type Error = Error;
-
-    fn try_from(serde_value: SerdeValue) -> Result<Self, Self::Error> {
-        match serde_value {
-            SerdeValue::Bool(bool) => Ok(Self::Bool(bool)),
-            SerdeValue::Number(number) => Ok(Self::Number(number)),
-            SerdeValue::String(string) => Ok(Self::String(string)),
-            SerdeValue::Array(serde_array) => {
-                let array = serde_array
-                    .into_iter()
-                    .map(Value::try_from)
-                    .collect::<Result<_, _>>()?;
-                Ok(Self::Array(array))
-            }
-            SerdeValue::Object(_) | SerdeValue::Null => Err(Error::TypeError),
-        }
-    }
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Default))]
+#[serde(rename_all = "camelCase")]
+pub struct AdView {
+    pub seconds_since_show: u64,
+    pub has_custom_preferences: bool,
 }
 
-impl Value {
-    pub fn try_bool(self) -> Result<bool, Error> {
-        match self {
-            Self::Bool(b) => Ok(b),
-            _ => Err(Error::TypeError),
-        }
-    }
-
-    pub fn try_array(self) -> Result<Vec<Value>, Error> {
-        match self {
-            Self::Array(array) => Ok(array),
-            _ => Err(Error::TypeError),
-        }
-    }
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Default))]
+#[serde(rename_all = "camelCase")]
+pub struct Global {
+    pub ad_slot_id: String,
+    pub ad_unit_id: String,
+    pub ad_unit_type: String,
+    pub publisher_id: String,
+    pub advertiser_id: String,
+    pub country: String,
+    pub event_type: String,
+    pub campaign_total_spent: String,
+    pub campaign_seconds_active: u64,
+    pub campaign_seconds_duration: u64,
+    pub campaign_budget: BigNum,
+    pub event_min_price: BigNum,
+    pub event_max_price: BigNum,
+    pub publisher_earned_from_campaign: BigNum,
+    pub seconds_since_epoch: u64,
+    #[serde(rename = "userAgentOS")]
+    pub user_agent_os: String,
+    pub user_agent_browser_family: String,
 }
 
-/// Evaluates a Rule to be applied and has 3 outcomes:
-/// - Does nothing
-///     Rules returned directly:
-///     - Bool
-///     - Number
-///     - String
-///     - Array
-/// - Mutates output
-/// - Throws an error
-pub fn eval(input: &Map, output: &mut Map, rule: &Rule) -> Result<Option<Value>, Error> {
-    let function = match rule {
-        Rule::Value(value) => return Ok(Some(value.clone())),
-        Rule::Function(function) => function,
-    };
 
-    // basic operators
-    let value = match function {
-        Function::If(first_rule, second_rule) => {
-            let eval_if = eval(input, output, first_rule)?
-                .ok_or(Error::TypeError)?
-                .try_bool()?;
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(test, derive(Default))]
+#[serde(rename_all = "camelCase")]
+pub struct AdSlot {
+    pub categories: Vec<String>,
+    pub hostname: String,
+    pub alexa_rank: f64,
+}
 
-            if eval_if {
-                let bool = eval(input, output, second_rule)?
-                    .ok_or(Error::TypeError)?
-                    .try_bool()?;
-                Some(Value::Bool(bool))
-            } else {
-                None
-            }
-        }
-        Function::And(first_rule, second_rule) => {
-            let a = eval(input, output, first_rule)?
-                .ok_or(Error::TypeError)?
-                .try_bool()?;
-            let b = eval(input, output, second_rule)?
-                .ok_or(Error::TypeError)?
-                .try_bool()?;
-
-            Some(Value::Bool(a && b))
-        }
-        Function::Intersects(first_rule, second_rule) => {
-            let a = eval(input, output, first_rule)?
-                .ok_or(Error::TypeError)?
-                .try_array()?;
-            let b = eval(input, output, second_rule)?
-                .ok_or(Error::TypeError)?
-                .try_array()?;
-
-            Some(Value::Bool(a.iter().any(|x| b.contains(x))))
-        }
-        Function::Get(key) => {
-            let input_value = input.get(key).ok_or(Error::UnknownVariable)?;
-
-            Some(Value::try_from(input_value.clone())?)
-        }
-    };
-
-    Ok(value)
+pub struct Output {
+    /// Whether to show the ad
+    /// Default: true
+    pub show: bool,
+    /// The boost is a number between 0 and 5 that increases the likelyhood for the ad
+    /// to be chosen if there is random selection applied on the AdView (multiple ad candidates with the same price)
+    /// Default: 1.0
+    pub boost: f64,
+    /// price.{eventType}
+    /// For example: price.IMPRESSION
+    /// The default is the min of the bound of event type:
+    /// Default: pricingBounds.IMPRESSION.min
+    pub price: HashMap<String, BigNum>,
 }
 
 #[cfg(test)]
@@ -152,67 +118,16 @@ mod test {
     use super::*;
 
     #[test]
-    fn deserialzes_intersects_rule() {
-        let json = r#"{"intersects": [{ "get": "adSlot.categories" }, ["News", "Bitcoin"]]}"#;
+    fn test_try_get_of_input() {
+        let mut input = Input::default();
+        input.ad_view = Some(AdView {
+            seconds_since_show: 10, has_custom_preferences: false
+        });
 
-        let parsed_rule = serde_json::from_str::<Rule>(json).expect("Should deserialize");
+        let result = input.try_get("adView.secondsSinceShow").expect("Should get the adView field");
 
-        let mut expected_map = SerdeMap::new();
-        expected_map.insert(
-            "get".to_string(),
-            SerdeValue::String("adSlot.categories".to_string()),
-        );
+        let expected = serde_json::from_str::<serde_json::Number>("10").expect("Should create number");
 
-        let expected = Rule::Function(Function::Intersects(
-            Box::new(Rule::Function(Function::Get(
-                "adSlot.categories".to_string(),
-            ))),
-            Box::new(Rule::Value(Value::Array(vec![
-                Value::String("News".to_string()),
-                Value::String("Bitcoin".to_string()),
-            ]))),
-        ));
-
-        assert_eq!(expected, parsed_rule)
-    }
-
-    /// ```json
-    /// {
-    ///   "intersects": [
-    ///     {
-    ///       "get": "publisherId"
-    ///     },
-    ///     [
-    ///       "0xd5860D6196A4900bf46617cEf088ee6E6b61C9d6",
-    ///       "0xd5860D6196A4900bf46617cEf088ee6E6b61C9d3"
-    ///     ]
-    ///   ]
-    /// }
-    /// ```
-    #[test]
-    fn test_simple_intersect_eval() {
-        let input: Map = vec![(
-            "publisherId".to_string(),
-            SerdeValue::Array(vec![SerdeValue::String(
-                "0xd5860D6196A4900bf46617cEf088ee6E6b61C9d6".to_string(),
-            )]),
-        )]
-        .into_iter()
-        .collect();
-        let mut output = SerdeMap::new();
-
-        let publishers = vec![
-            Value::String("0xd5860D6196A4900bf46617cEf088ee6E6b61C9d6".to_string()),
-            Value::String("0xd5860D6196A4900bf46617cEf088ee6E6b61C9d3".to_string()),
-        ];
-
-        let rules = Rule::Function(Function::Intersects(
-            Box::new(Rule::Function(Function::Get("publisherId".to_string()))),
-            Box::new(Rule::Value(Value::Array(publishers))),
-        ));
-
-        let result = eval(&input, &mut output, &rules).expect("Should eval rules");
-
-        assert_eq!(Value::Bool(true), result.expect("Sould be Some!"));
+        assert_eq!(Value::Number(expected), result)
     }
 }

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -1,4 +1,4 @@
-use crate::BigNum;
+use crate::{BigNum, Channel};
 use std::collections::HashMap;
 
 pub use eval::*;
@@ -137,6 +137,25 @@ pub struct Output {
     /// The default is the min of the bound of event type:
     /// Default: pricingBounds.IMPRESSION.min
     pub price: HashMap<String, BigNum>,
+}
+
+impl From<&Channel> for Output {
+    fn from(channel: &Channel) -> Self {
+        let price = match &channel.spec.pricing_bounds {
+            Some(pricing_bounds) => pricing_bounds
+                .to_vec()
+                .into_iter()
+                .map(|(key, price)| (key.to_string(), price.min))
+                .collect(),
+            _ => Default::default(),
+        };
+
+        Self {
+            show: true,
+            boost: 1.0,
+            price,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -1,23 +1,18 @@
 use crate::BigNum;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub use eval::*;
 
 mod eval;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(Default))]
-#[serde(rename_all = "camelCase")]
 pub struct Input {
     /// AdView scope, accessible only on the AdView
-    #[serde(default)]
     pub ad_view: Option<AdView>,
     /// Global scope, accessible everywhere
-    #[serde(flatten)]
     pub global: Global,
     /// adSlot scope, accessible on Supermarket and AdView
-    #[serde(default)]
     pub ad_slot: Option<AdSlot>,
 }
 
@@ -90,17 +85,15 @@ impl Input {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(Default))]
-#[serde(rename_all = "camelCase")]
 pub struct AdView {
     pub seconds_since_show: u64,
     pub has_custom_preferences: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(Default))]
-#[serde(rename_all = "camelCase")]
 pub struct Global {
     pub ad_slot_id: String,
     pub ad_unit_id: String,
@@ -118,14 +111,12 @@ pub struct Global {
     pub event_max_price: BigNum,
     pub publisher_earned_from_campaign: BigNum,
     pub seconds_since_epoch: u64,
-    #[serde(rename = "userAgentOS")]
     pub user_agent_os: String,
     pub user_agent_browser_family: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(Default))]
-#[serde(rename_all = "camelCase")]
 pub struct AdSlot {
     pub categories: Vec<String>,
     pub hostname: String,

--- a/primitives/src/targeting/eval.rs
+++ b/primitives/src/targeting/eval.rs
@@ -1,0 +1,276 @@
+use crate::BigNum;
+use serde::{Deserialize, Serialize};
+use serde_json::{value::Value as SerdeValue, Number};
+use std::convert::TryFrom;
+use std::fmt;
+
+pub type Map = serde_json::value::Map<String, SerdeValue>;
+
+#[derive(Debug)]
+pub enum Error {
+    TypeError,
+    UnknownVariable,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::TypeError => write!(f, "TypeError: Wrong type"),
+            Error::UnknownVariable => write!(f, "UnknownVariable: Unknown varialbe passed"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Rule {
+    Function(Function),
+    Value(Value),
+}
+
+impl Rule {
+    pub fn eval(&self, input: &Map, output: &mut Map) -> Result<Option<Value>, Error> {
+        eval(input, output, self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "SerdeValue")]
+pub enum Value {
+    Bool(bool),
+    Number(Number),
+    String(String),
+    Array(Vec<Value>),
+    BigNum(BigNum),
+}
+
+impl Value {
+    pub fn new_string(string: &str) -> Self {
+        Self::String(string.to_string())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum Function {
+    If(Box<Rule>, Box<Rule>),
+    And(Box<Rule>, Box<Rule>),
+    Intersects(Box<Rule>, Box<Rule>),
+    Get(String),
+    // TODO: set
+
+    // TODO: Add: div, mul, mod, add, sub, max, min
+}
+
+impl From<Function> for Rule {
+    fn from(function: Function) -> Self {
+        Self::Function(function)
+    }
+}
+
+impl From<Value> for Rule {
+    fn from(value: Value) -> Self {
+        Self::Value(value)
+    }
+}
+
+impl Function {
+    pub fn new_if(lhs: impl Into<Rule>, rhs: impl Into<Rule>) -> Self {
+        Self::If(Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    pub fn new_and(lhs: impl Into<Rule>, rhs: impl Into<Rule>) -> Self {
+        Self::And(Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    pub fn new_intersects(lhs: impl Into<Rule>, rhs: impl Into<Rule>) -> Self {
+        Self::Intersects(Box::new(lhs.into()), Box::new(rhs.into()))
+    }
+
+    pub fn new_get(key: &str) -> Self {
+        Self::Get(key.to_string())
+    }
+}
+
+impl TryFrom<SerdeValue> for Value {
+    type Error = Error;
+
+    fn try_from(serde_value: SerdeValue) -> Result<Self, Self::Error> {
+        match serde_value {
+            SerdeValue::Bool(bool) => Ok(Self::Bool(bool)),
+            SerdeValue::Number(number) => Ok(Self::Number(number)),
+            SerdeValue::String(string) => Ok(Self::String(string)),
+            SerdeValue::Array(serde_array) => {
+                let array = serde_array
+                    .into_iter()
+                    .map(Value::try_from)
+                    .collect::<Result<_, _>>()?;
+                Ok(Self::Array(array))
+            }
+            SerdeValue::Object(_) | SerdeValue::Null => Err(Error::TypeError),
+        }
+    }
+}
+
+impl Value {
+    pub fn try_bool(self) -> Result<bool, Error> {
+        match self {
+            Self::Bool(b) => Ok(b),
+            _ => Err(Error::TypeError),
+        }
+    }
+
+    pub fn try_array(self) -> Result<Vec<Value>, Error> {
+        match self {
+            Self::Array(array) => Ok(array),
+            _ => Err(Error::TypeError),
+        }
+    }
+}
+
+/// Evaluates a Rule to be applied and has 3 outcomes:
+/// - Does nothing
+///     Rules returned directly:
+///     - Bool
+///     - Number
+///     - String
+///     - Array
+/// - Mutates output
+/// - Throws an error
+fn eval(input: &Map, output: &mut Map, rule: &Rule) -> Result<Option<Value>, Error> {
+    let function = match rule {
+        Rule::Value(value) => return Ok(Some(value.clone())),
+        Rule::Function(function) => function,
+    };
+
+    // basic operators
+    let value = match function {
+        Function::If(first_rule, second_rule) => {
+            let eval_if = eval(input, output, first_rule)?
+                .ok_or(Error::TypeError)?
+                .try_bool()?;
+
+            if eval_if {
+                let bool = eval(input, output, second_rule)?
+                    .ok_or(Error::TypeError)?
+                    .try_bool()?;
+                Some(Value::Bool(bool))
+            } else {
+                None
+            }
+        }
+        Function::And(first_rule, second_rule) => {
+            let a = eval(input, output, first_rule)?
+                .ok_or(Error::TypeError)?
+                .try_bool()?;
+            let b = eval(input, output, second_rule)?
+                .ok_or(Error::TypeError)?
+                .try_bool()?;
+
+            Some(Value::Bool(a && b))
+        }
+        Function::Intersects(first_rule, second_rule) => {
+            let a = eval(input, output, first_rule)?
+                .ok_or(Error::TypeError)?
+                .try_array()?;
+            let b = eval(input, output, second_rule)?
+                .ok_or(Error::TypeError)?
+                .try_array()?;
+
+            Some(Value::Bool(a.iter().any(|x| b.contains(x))))
+        }
+        Function::Get(key) => {
+            let input_value = input.get(key).ok_or(Error::UnknownVariable)?;
+
+            Some(Value::try_from(input_value.clone())?)
+        }
+    };
+
+    Ok(value)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn deserialzes_intersects_rule() {
+        let json = r#"{"intersects": [{ "get": "adSlot.categories" }, ["News", "Bitcoin"]]}"#;
+
+        let parsed_rule = serde_json::from_str::<Rule>(json).expect("Should deserialize");
+
+        let mut expected_map = Map::new();
+        expected_map.insert(
+            "get".to_string(),
+            SerdeValue::String("adSlot.categories".to_string()),
+        );
+
+        let expected = Rule::Function(Function::new_intersects(
+            Rule::Function(Function::new_get("adSlot.categories")),
+            Rule::Value(Value::Array(vec![
+                Value::new_string("News"),
+                Value::new_string("Bitcoin"),
+            ])),
+        ));
+
+        assert_eq!(expected, parsed_rule)
+    }
+
+    /// ```json
+    /// {
+    ///   "intersects": [
+    ///     {
+    ///       "get": "adSlot.categories"
+    ///     },
+    ///     [
+    ///       "News",
+    ///       "Bitcoin"
+    ///     ]
+    ///   ]
+    /// }
+    /// ```
+    #[test]
+    fn test_intersects_eval() {
+        let input: Map = vec![(
+            "adSlot.categories".to_string(),
+            SerdeValue::Array(vec![
+                SerdeValue::String("Bitcoin".to_string()),
+                SerdeValue::String("Ethereum".to_string()),
+            ]),
+        )]
+        .into_iter()
+        .collect();
+        let mut output = Map::new();
+
+        let categories = vec![Value::new_string("News"), Value::new_string("Bitcoin")];
+
+        let rules = Rule::Function(Function::new_intersects(
+            Function::new_get("adSlot.categories"),
+            Value::Array(categories),
+        ));
+
+        let result = rules.eval(&input, &mut output).expect("Should eval rules");
+
+        assert_eq!(
+            Value::Bool(true),
+            result.expect("Sould return Non-NULL result!")
+        );
+
+        let input: Map = vec![(
+            "adSlot.categories".to_string(),
+            SerdeValue::Array(vec![
+                SerdeValue::String("Advertisement".to_string()),
+                SerdeValue::String("Programming".to_string()),
+            ]),
+        )]
+        .into_iter()
+        .collect();
+
+        let result = rules.eval(&input, &mut output).expect("Should eval rules");
+
+        assert_eq!(
+            Value::Bool(false),
+            result.expect("Sould return Non-NULL result!")
+        );
+    }
+}

--- a/primitives/src/targeting/eval.rs
+++ b/primitives/src/targeting/eval.rs
@@ -17,10 +17,12 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::TypeError => write!(f, "TypeError: Wrong type"),
-            Error::UnknownVariable => write!(f, "UnknownVariable: Unknown varialbe passed"),
+            Error::UnknownVariable => write!(f, "UnknownVariable: Unknown variable passed"),
         }
     }
 }
+
+impl std::error::Error for Error {}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
@@ -322,16 +324,10 @@ mod test {
     use crate::targeting::AdSlot;
 
     #[test]
-    fn deserialzes_intersects_rule() {
+    fn deserialize_intersects_with_get_rule() {
         let json = r#"{"intersects": [{ "get": "adSlot.categories" }, ["News", "Bitcoin"]]}"#;
 
         let parsed_rule = serde_json::from_str::<Rule>(json).expect("Should deserialize");
-
-        let mut expected_map = Map::new();
-        expected_map.insert(
-            "get".to_string(),
-            SerdeValue::String("adSlot.categories".to_string()),
-        );
 
         let expected = Rule::Function(Function::new_intersects(
             Rule::Function(Function::new_get("adSlot.categories")),
@@ -383,7 +379,7 @@ mod test {
 
         assert_eq!(
             Value::Bool(true),
-            result.expect("Sould return Non-NULL result!")
+            result.expect("Should return Non-NULL result!")
         );
 
         let mut input = Input::default();
@@ -397,7 +393,7 @@ mod test {
 
         assert_eq!(
             Value::Bool(false),
-            result.expect("Sould return Non-NULL result!")
+            result.expect("Should return Non-NULL result!")
         );
     }
 
@@ -456,12 +452,12 @@ mod test {
 
         let cases = vec![
             (Value::new_string("1000"), Value::BigNum(1000.into())),
-            (Value::new_number(5000), Value::BigNum(5000.into())),
-            (Value::BigNum(2.into()), Value::BigNum(2.into())),
+            (Value::new_number(2_000), Value::BigNum(2_000.into())),
+            (Value::BigNum(3.into()), Value::BigNum(3.into())),
             // rounded floats should work!
             (
-                Value::Number(Number::from_f64(2.0).expect("should create float number")),
-                Value::BigNum(2.into()),
+                Value::Number(Number::from_f64(40.0).expect("should create float number")),
+                Value::BigNum(40.into()),
             ),
         ];
 
@@ -483,7 +479,7 @@ mod test {
 
         let error_cases = vec![
             Value::new_string("text"),
-            // BigNums can only be possitive
+            // BigNums can only be positive
             Value::new_number(-100),
             Value::Bool(true),
             Value::Array(vec![Value::Bool(false)]),

--- a/primitives/src/targeting/eval.rs
+++ b/primitives/src/targeting/eval.rs
@@ -58,8 +58,8 @@ impl TryFrom<SerdeValue> for Value {
         match serde_value {
             SerdeValue::Bool(bool) => Ok(Self::Bool(bool)),
             SerdeValue::Number(number) => Ok(Self::Number(number)),
-            // String can be either a String or a BigNum
-            // but we handle this case by using Type casting with the Function::Bn
+            // It's impossible to have a BigNumber literal in the rules, since they're JSON based (conform to serde_json::value::Value)
+            // However it is possible to obtain a BigNumber by invoking the Function::Bn
             SerdeValue::String(string) => Ok(Value::String(string)),
             SerdeValue::Array(serde_array) => {
                 let array = serde_array


### PR DESCRIPTION
Partially implements #296 (see for more details)

### Values:
- [x] #297 `Bool(bool)`
- [x] #297 `Number(Number)`
- [x] #297 `String(String)`
- [x] #297 `Array(Vec<Value>)`
- [x] #297 `BigNum(BigNum)`

#### Math
- [x] #297 `Div(Box<Rule>, Box<Rule>)`

#### Variables
- [x] #297 `Get(String)`
- [x] #297 `Set(String, Box<Rule>)`

#### Logic
- [x] #297 `And(Box<Rule>, Box<Rule>)`

#### Flow control
- [x] #297 `If(Box<Rule>, Box<Rule>)`

#### Comparison
- [x] #297 `Intersects(Box<Rule>, Box<Rule>)`

#### Type Cast
- [x] #297 `Bn(BigNum)`