### PR TITLE
AdEx v5: Issue #384 Unified precision - primitives::UnifiedNum

### DIFF
--- a/primitives/src/big_num.rs
+++ b/primitives/src/big_num.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 
-use num::{rational::Ratio, BigUint, CheckedSub, Integer};
+use num::{pow::Pow, rational::Ratio, BigUint, CheckedSub, Integer};
 use num_derive::{Num, NumOps, One, Zero};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -96,6 +96,46 @@ impl Integer for BigNum {
         let (quotient, remainder) = self.0.div_rem(&other.0);
 
         (quotient.into(), remainder.into())
+    }
+}
+
+impl Pow<BigNum> for BigNum {
+    type Output = BigNum;
+
+    fn pow(self, rhs: BigNum) -> Self::Output {
+        Self(self.0.pow(rhs.0))
+    }
+}
+
+impl Pow<&BigNum> for BigNum {
+    type Output = BigNum;
+
+    fn pow(self, rhs: &BigNum) -> Self::Output {
+        BigNum(self.0.pow(&rhs.0))
+    }
+}
+
+impl Pow<BigNum> for &BigNum {
+    type Output = BigNum;
+
+    fn pow(self, rhs: BigNum) -> Self::Output {
+        BigNum(Pow::pow(&self.0, rhs.0))
+    }
+}
+
+impl Pow<&BigNum> for &BigNum {
+    type Output = BigNum;
+
+    fn pow(self, rhs: &BigNum) -> Self::Output {
+        BigNum(Pow::pow(&self.0, &rhs.0))
+    }
+}
+
+impl Pow<u8> for BigNum {
+    type Output = BigNum;
+
+    fn pow(self, rhs: u8) -> Self::Output {
+        BigNum(self.0.pow(rhs))
     }
 }
 

--- a/primitives/src/big_num.rs
+++ b/primitives/src/big_num.rs
@@ -1,11 +1,12 @@
-use std::convert::TryFrom;
-use std::fmt;
-use std::iter::Sum;
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
-use std::str::FromStr;
+use std::{
+    convert::TryFrom,
+    fmt,
+    iter::Sum,
+    ops::{Add, AddAssign, Div, Mul, Sub},
+    str::FromStr,
+};
 
-use num::rational::Ratio;
-use num::{BigUint, CheckedSub, Integer};
+use num::{rational::Ratio, BigUint, CheckedSub, Integer};
 use num_derive::{Num, NumOps, One, Zero};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/primitives/src/big_num.rs
+++ b/primitives/src/big_num.rs
@@ -10,6 +10,8 @@ use num::{pow::Pow, rational::Ratio, BigUint, CheckedSub, Integer};
 use num_derive::{Num, NumOps, One, Zero};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::UnifiedNum;
+
 #[derive(
     Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd, Ord, NumOps, One, Zero, Num, Default,
 )]
@@ -265,6 +267,12 @@ impl From<u64> for BigNum {
 impl From<BigUint> for BigNum {
     fn from(value: BigUint) -> Self {
         Self(value)
+    }
+}
+
+impl<'a> Sum<&'a UnifiedNum> for BigNum {
+    fn sum<I: Iterator<Item = &'a UnifiedNum>>(iter: I) -> BigNum {
+        BigNum(iter.map(|unified| BigUint::from(unified.to_u64())).sum())
     }
 }
 

--- a/primitives/src/big_num.rs
+++ b/primitives/src/big_num.rs
@@ -59,6 +59,12 @@ impl fmt::Debug for BigNum {
     }
 }
 
+impl fmt::Display for BigNum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl Integer for BigNum {
     fn div_floor(&self, other: &Self) -> Self {
         self.0.div_floor(&other.0).into()
@@ -250,12 +256,6 @@ impl FromStr for BigNum {
     }
 }
 
-impl ToString for BigNum {
-    fn to_string(&self) -> String {
-        self.0.to_str_radix(10)
-    }
-}
-
 impl From<u64> for BigNum {
     fn from(value: u64) -> Self {
         Self(BigUint::from(value))
@@ -337,5 +337,12 @@ mod test {
 
         let expected: BigNum = 11.into();
         assert_eq!(expected, &big_num * &ratio);
+    }
+    #[test]
+    fn bignum_formatting() {
+        let bignum: BigNum = 5000.into();
+
+        assert_eq!("5000", &bignum.to_string());
+        assert_eq!("BigNum(radix: 10; 5000)", &format!("{:?}", &bignum));
     }
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(clippy::all)]
+use std::{error, fmt};
+
 pub use self::{
     ad_slot::AdSlot,
     ad_unit::AdUnit,
@@ -10,14 +12,15 @@ pub use self::{
     config::Config,
     event_submission::EventSubmission,
     ipfs::IPFS,
+    unified_num::UnifiedNum,
     validator::{ValidatorDesc, ValidatorId},
 };
-use std::{error, fmt};
 
 mod ad_slot;
 mod ad_unit;
 pub mod adapter;
 pub mod address;
+pub mod analytics;
 pub mod balances_map;
 pub mod big_num;
 pub mod campaign;
@@ -25,6 +28,7 @@ pub mod channel;
 pub mod channel_v5;
 pub mod channel_validator;
 pub mod config;
+mod eth_checksum;
 pub mod event_submission;
 pub mod ipfs;
 pub mod market;
@@ -32,6 +36,8 @@ pub mod merkle_tree;
 pub mod sentry;
 pub mod supermarket;
 pub mod targeting;
+mod unified_num;
+pub mod validator;
 
 pub mod util {
     pub use api::ApiUrl;
@@ -52,9 +58,6 @@ pub mod util {
 
     pub mod logging;
 }
-pub mod analytics;
-mod eth_checksum;
-pub mod validator;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DomainError {

--- a/primitives/src/unified_num.rs
+++ b/primitives/src/unified_num.rs
@@ -10,7 +10,10 @@ use std::{
 
 use crate::BigNum;
 
-/// Unified precision Number with precision 8
+/// Unified Number with a precision of 8 digits after the decimal point
+/// The number can be a maximum of `u64::MAX` (the underlying type),
+/// or in a `UnifiedNum` value `184_467_440_737.09551615`
+/// The actual number is handled as a unsigned number and only the display shows the decimal point
 #[derive(
     Clone,
     Copy,

--- a/primitives/src/unified_num.rs
+++ b/primitives/src/unified_num.rs
@@ -76,7 +76,7 @@ impl fmt::Debug for UnifiedNum {
 
 impl One for UnifiedNum {
     fn one() -> Self {
-        Self(BigNum::from(10_000_000))
+        Self(BigNum::from(100_000_000))
     }
 }
 
@@ -247,6 +247,7 @@ impl CheckedSub for UnifiedNum {
 #[cfg(test)]
 mod test {
     use super::*;
+    use num::Zero;
 
     #[test]
     fn unified_num_displays_correctly() {
@@ -256,6 +257,8 @@ mod test {
         let random_value = UnifiedNum::from(144_903_000_567_000);
 
         assert_eq!("1.00000000", &one.to_string());
+        assert_eq!("1.00000000", &UnifiedNum::one().to_string());
+        assert_eq!("0.00000000", &UnifiedNum::zero().to_string());
         assert_eq!("0.10000000", &zero_point_one.to_string());
         assert_eq!("0.00000001", &smallest_value.to_string());
         assert_eq!("1449030.00567000", &random_value.to_string());

--- a/primitives/src/unified_num.rs
+++ b/primitives/src/unified_num.rs
@@ -309,7 +309,7 @@ mod test {
             "It should floor the result of USDT"
         );
 
-        // 321.00000999
+        // 321.00000777
         let same_unified = UnifiedNum::from(32_100_000_777_u64);
         assert_eq!(
             BigNum::from(same_unified.0),

--- a/primitives/src/unified_num.rs
+++ b/primitives/src/unified_num.rs
@@ -1,0 +1,218 @@
+use num::{CheckedSub, Integer, One};
+use num_derive::{Num, NumOps, Zero};
+use std::{
+    fmt,
+    iter::Sum,
+    ops::{Add, AddAssign, Div, Mul, Sub},
+};
+
+use crate::BigNum;
+
+/// Unified precision Number with precision 8
+#[derive(Num, NumOps, Zero, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct UnifiedNum(BigNum);
+
+impl UnifiedNum {
+    pub const PRECISION: usize = 8;
+
+    pub fn div_floor(&self, other: &Self) -> Self {
+        Self(self.0.div_floor(&other.0))
+    }
+
+    pub fn to_f64(&self) -> Option<f64> {
+        self.0.to_f64()
+    }
+
+    pub fn to_u64(&self) -> Option<u64> {
+        self.0.to_u64()
+    }
+}
+
+impl From<u64> for UnifiedNum {
+    fn from(number: u64) -> Self {
+        Self(BigNum::from(number))
+    }
+}
+
+impl From<BigNum> for UnifiedNum {
+    fn from(number: BigNum) -> Self {
+        Self(number)
+    }
+}
+
+impl fmt::Display for UnifiedNum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut string_value = self.0.to_str_radix(10);
+        let value_length = string_value.len();
+
+        if value_length > Self::PRECISION {
+            string_value.insert_str(value_length - Self::PRECISION, ".");
+
+            f.write_str(&string_value)
+        } else {
+            write!(f, "0.{:0>8}", string_value)
+        }
+    }
+}
+
+impl fmt::Debug for UnifiedNum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UnifiedNum({})", self.to_string())
+    }
+}
+
+impl One for UnifiedNum {
+    fn one() -> Self {
+        Self(BigNum::from(10_000_000))
+    }
+}
+
+impl Integer for UnifiedNum {
+    fn div_floor(&self, other: &Self) -> Self {
+        self.0.div_floor(&other.0).into()
+    }
+
+    fn mod_floor(&self, other: &Self) -> Self {
+        self.0.mod_floor(&other.0).into()
+    }
+
+    fn gcd(&self, other: &Self) -> Self {
+        self.0.gcd(&other.0).into()
+    }
+
+    fn lcm(&self, other: &Self) -> Self {
+        self.0.lcm(&other.0).into()
+    }
+
+    fn divides(&self, other: &Self) -> bool {
+        self.0.divides(&other.0)
+    }
+
+    fn is_multiple_of(&self, other: &Self) -> bool {
+        self.0.is_multiple_of(&other.0)
+    }
+
+    fn is_even(&self) -> bool {
+        self.0.is_even()
+    }
+
+    fn is_odd(&self) -> bool {
+        !self.is_even()
+    }
+
+    fn div_rem(&self, other: &Self) -> (Self, Self) {
+        let (quotient, remainder) = self.0.div_rem(&other.0);
+
+        (quotient.into(), remainder.into())
+    }
+}
+
+impl Add<&UnifiedNum> for &UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn add(self, rhs: &UnifiedNum) -> Self::Output {
+        let bignum = &self.0 + &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl AddAssign<&UnifiedNum> for UnifiedNum {
+    fn add_assign(&mut self, rhs: &UnifiedNum) {
+        self.0 += &rhs.0
+    }
+}
+
+impl Sub<&UnifiedNum> for &UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn sub(self, rhs: &UnifiedNum) -> Self::Output {
+        let bignum = &self.0 - &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl Sub<&UnifiedNum> for UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn sub(self, rhs: &UnifiedNum) -> Self::Output {
+        let bignum = &self.0 - &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl Sub<UnifiedNum> for &UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn sub(self, rhs: UnifiedNum) -> Self::Output {
+        let bignum = &self.0 - &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl Div<&UnifiedNum> for &UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn div(self, rhs: &UnifiedNum) -> Self::Output {
+        let bignum = &self.0 / &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl Div<&UnifiedNum> for UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn div(self, rhs: &UnifiedNum) -> Self::Output {
+        let bignum = &self.0 / &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl Mul<&UnifiedNum> for &UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn mul(self, rhs: &UnifiedNum) -> Self::Output {
+        let bignum = &self.0 * &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl Mul<&UnifiedNum> for UnifiedNum {
+    type Output = UnifiedNum;
+
+    fn mul(self, rhs: &UnifiedNum) -> Self::Output {
+        let bignum = &self.0 * &rhs.0;
+        UnifiedNum(bignum)
+    }
+}
+
+impl<'a> Sum<&'a UnifiedNum> for UnifiedNum {
+    fn sum<I: Iterator<Item = &'a UnifiedNum>>(iter: I) -> Self {
+        let sum_uint = iter.map(|big_num| &big_num.0).sum();
+
+        Self(sum_uint)
+    }
+}
+
+impl CheckedSub for UnifiedNum {
+    fn checked_sub(&self, v: &Self) -> Option<Self> {
+        self.0.checked_sub(&v.0).map(Self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::UnifiedNum;
+
+    #[test]
+    fn unified_num_displays_correctly() {
+        let one = UnifiedNum::from(100_000_000);
+        let zero_point_one = UnifiedNum::from(10_000_000);
+        let smallest_value = UnifiedNum::from(1);
+        let random_value = UnifiedNum::from(144_903_000_567_000);
+
+        assert_eq!("1.00000000", &one.to_string());
+        assert_eq!("0.10000000", &zero_point_one.to_string());
+        assert_eq!("0.00000001", &smallest_value.to_string());
+        assert_eq!("1449030.00567000", &random_value.to_string());
+    }
+}

--- a/sentry/src/middleware/auth.rs
+++ b/sentry/src/middleware/auth.rs
@@ -133,7 +133,7 @@ mod test {
 
     use primitives::util::tests::prep_db::{AUTH, IDS};
 
-    use primitives::{config::configuration};
+    use primitives::config::configuration;
 
     use deadpool::managed::Object;
 


### PR DESCRIPTION
Changelog:
- Add `primitives::UnifiedNum` for #384 with precision of 8