### PR TITLE
Fixed propagate()

### DIFF
--- a/validator_worker/src/heartbeat.rs
+++ b/validator_worker/src/heartbeat.rs
@@ -5,7 +5,7 @@ use byteorder::{BigEndian, ByteOrder};
 use primitives::{
     merkle_tree::MerkleTree,
     validator::{Heartbeat, MessageTypes},
-    ChannelId,
+    Channel,
 };
 use thiserror::Error;
 
@@ -25,9 +25,9 @@ pub enum Error {
 
 pub async fn heartbeat<C: Unlocked + 'static>(
     iface: &SentryApi<C>,
-    channel: ChannelId,
+    channel: Channel,
 ) -> Result<HeartbeatStatus, Error> {
-    let validator_message_response = iface.get_our_latest_msg(channel, &["Heartbeat"]).await?;
+    let validator_message_response = iface.get_our_latest_msg(channel.id(), &["Heartbeat"]).await?;
     let heartbeat_msg = match validator_message_response {
         Some(MessageTypes::Heartbeat(heartbeat)) => Some(heartbeat),
         _ => None,
@@ -47,7 +47,7 @@ pub async fn heartbeat<C: Unlocked + 'static>(
 
 async fn send_heartbeat<C: Unlocked + 'static>(
     iface: &SentryApi<C>,
-    channel: ChannelId,
+    channel: Channel,
 ) -> Result<Vec<PropagationResult>, Error> {
     let mut timestamp_buf = [0_u8; 32];
     let milliseconds: u64 = u64::try_from(Utc::now().timestamp_millis())
@@ -56,7 +56,7 @@ async fn send_heartbeat<C: Unlocked + 'static>(
 
     let merkle_tree = MerkleTree::new(&[timestamp_buf])?;
 
-    let state_root_raw = get_signable_state_root(channel.as_ref(), &merkle_tree.root());
+    let state_root_raw = get_signable_state_root(channel.id().as_ref(), &merkle_tree.root());
     let state_root = hex::encode(state_root_raw);
 
     let signature = iface.adapter.sign(&state_root)?;

--- a/validator_worker/src/leader.rs
+++ b/validator_worker/src/leader.rs
@@ -5,7 +5,7 @@ use primitives::{
     balances::CheckedState,
     config::TokenInfo,
     validator::{MessageError, MessageTypes, NewState},
-    Balances, Channel, ChannelId,
+    Balances, Channel,
 };
 
 use crate::{
@@ -91,24 +91,24 @@ pub async fn tick<C: Unlocked + 'static>(
 
     // Create a `NewState` if balances have changed
     let new_state = if should_generate_new_state {
-        Some(on_new_accounting(sentry, channel.id(), accounting_balances, token).await?)
+        Some(on_new_accounting(sentry, channel, accounting_balances, token).await?)
     } else {
         None
     };
 
     Ok(TickStatus {
-        heartbeat: heartbeat(sentry, channel.id()).await?,
+        heartbeat: heartbeat(sentry, channel).await?,
         new_state,
     })
 }
 
 async fn on_new_accounting<C: Unlocked + 'static>(
     sentry: &SentryApi<C>,
-    channel: ChannelId,
+    channel: Channel,
     accounting_balances: Balances<CheckedState>,
     token: &TokenInfo,
 ) -> Result<Vec<PropagationResult>, Error> {
-    let state_root = accounting_balances.encode(channel, token.precision.get())?;
+    let state_root = accounting_balances.encode(channel.id(), token.precision.get())?;
 
     let signature = sentry.adapter.sign(&state_root)?;
 


### PR DESCRIPTION
Changed propagate() to use Channel instead of ChannelId so that it can filter out only the `channel.leader` and `channel.follower` validators to propagate to.