### PR TITLE
Fix randomly failing campaign test

### DIFF
--- a/primitives/src/campaign.rs
+++ b/primitives/src/campaign.rs
@@ -29,12 +29,18 @@ mod campaign_id {
     use thiserror::Error;
     use uuid::Uuid;
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
     /// an Id of 16 bytes, (de)serialized as a `0x` prefixed hex
     ///
     /// In this implementation of the `CampaignId` the value is generated from a `Uuid::new_v4().to_simple()`
     pub struct CampaignId([u8; 16]);
 
+    impl fmt::Debug for CampaignId {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "CampaignId({})", self)
+        }
+    }
+    
     impl CampaignId {
         /// Generates randomly a `CampaignId` using `Uuid::new_v4().to_simple()`
         pub fn new() -> Self {

--- a/sentry/src/db.rs
+++ b/sentry/src/db.rs
@@ -553,7 +553,7 @@ pub mod redis_pool {
             }
         }
 
-        /// Flushing (`FLUSDB`) is synchronous by default in Redis
+        /// Flushing (`FLUSHDB`) is synchronous by default in Redis
         pub async fn flush_db(connection: &mut MultiplexedConnection) -> Result<String, Error> {
             redis::cmd("FLUSHDB")
                 .query_async::<_, String>(connection)
@@ -619,15 +619,17 @@ pub mod redis_pool {
         async fn recycle(&self, database: &mut Database) -> RecycleResult<Self::Error> {
             // always make a new connection because of know redis crate issue
             // see https://github.com/mitsuhiko/redis-rs/issues/325
-            let connection = redis_connection(format!("{}{}", Self::URL, database.index))
+            let mut connection = redis_connection(format!("{}{}", Self::URL, database.index))
                 .await
                 .expect("Should connect");
+            // first flush the database
+            // this avoids the problem of flushing after the DB is picked up again by the Pool
+            let flush_result = Self::flush_db(&mut connection).await;
             // make the database available
             database.available = true;
             database.connection = connection;
-            Self::flush_db(&mut database.connection)
-                .await
-                .expect("Should flush");
+
+            flush_result.expect("Should have flushed the redis DB successfully");
 
             Ok(())
         }

--- a/sentry/src/routes/campaign.rs
+++ b/sentry/src/routes/campaign.rs
@@ -1026,8 +1026,8 @@ mod test {
                 channel_context.context.id(),
                 for_address,
                 Deposit {
-                    // a deposit 4 times larger than the Campaign Budget
-                    // I.e. 4 TOKENS
+                    // a deposit 4 times larger than the first Campaign.budget = 500
+                    // I.e. 2 000 TOKENS
                     total: UnifiedNum::from(200_000_000_000)
                         .to_precision(channel_context.token.precision.get()),
                     still_on_create2: BigNum::from(0),
@@ -1089,6 +1089,10 @@ mod test {
         };
 
         // modify campaign
+        // Deposit = 2 000
+        // old Campaign.budget = 500
+        // new Campaign.budget = 1 000
+        // Deposit left = 1 000
         let modified = {
             let new_budget = UnifiedNum::from(1000 * multiplier);
             let modify = ModifyCampaign {
@@ -1100,7 +1104,9 @@ mod test {
                 ad_units: None,
                 targeting_rules: None,
             };
-            // prepare for Campaign modification
+
+            // prepare for Campaign modification.
+            // does not alter the deposit amount
             add_deposit_call(&channel_context, campaign_context.context.creator);
 
             let modified_campaign = modify_campaign(
@@ -1121,6 +1127,9 @@ mod test {
         };
 
         // we have 1000 left from our deposit, so we are using half of it
+        // remaining Deposit = 1 000
+        // new Campaign.budget = 500
+        // Deposit left = 500
         let _second_campaign = {
             // erases the CampaignId for the CreateCampaign request
             let mut create_second =
@@ -1146,8 +1155,8 @@ mod test {
         };
 
         // No budget left for new campaigns
-        // remaining: 500
-        // new campaign budget: 600
+        // remaining Deposit = 500
+        // new Campaign.budget = 600
         {
             // erases the CampaignId for the CreateCampaign request
             let mut create = CreateCampaign::from_campaign_erased(DUMMY_CAMPAIGN.clone(), None);
@@ -1201,8 +1210,8 @@ mod test {
         };
 
         // Just enough budget to create this Campaign
-        // remaining: 600
-        // new campaign budget: 600
+        // remaining Deposit = 600
+        // new Campaign.budget = 600
         {
             // erases the CampaignId for the CreateCampaign request
             let mut create = CreateCampaign::from_campaign_erased(DUMMY_CAMPAIGN.clone(), None);
@@ -1224,9 +1233,9 @@ mod test {
         }
 
         // Modify a campaign without enough budget
-        // remaining: 0
-        // new campaign budget: 1100
-        // current campaign budget: 900
+        // remaining Deposit = 0
+        // new Campaign.budget = 1100
+        // current Campaign.budget = 900
         {
             let new_budget = UnifiedNum::from(110_000_000_000);
             let modify = ModifyCampaign {


### PR DESCRIPTION
The problem most probably was because the test pool database was made available **before** running the `FLUSHDB` which caused occasionally when tests run in parallel to clear up the DB