### PR TITLE
Remove unused structs and improve docs

### DIFF
--- a/adview-manager/src/lib.rs
+++ b/adview-manager/src/lib.rs
@@ -36,7 +36,7 @@ const IPFS_GATEWAY: &str = "https://ipfs.moonicorn.network/ipfs/";
 /// Related: <https://github.com/AdExNetwork/adex-adview-manager/issues/17>, <https://github.com/AdExNetwork/adex-adview-manager/issues/35>, <https://github.com/AdExNetwork/adex-adview-manager/issues/46>
 ///
 /// Used for JS [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout) function
-const WAIT_FOR_IMPRESSION: u32 = 8000;
+pub const WAIT_FOR_IMPRESSION: u32 = 8000;
 // The number of impressions (won auctions) kept in history
 const HISTORY_LIMIT: u32 = 50;
 

--- a/primitives/src/campaign.rs
+++ b/primitives/src/campaign.rs
@@ -10,6 +10,7 @@ use chrono::{
 use serde::{Deserialize, Serialize};
 use serde_with::with_prefix;
 
+#[doc(inline)]
 pub use {
     campaign_id::CampaignId,
     pricing::{Pricing, PricingBounds},

--- a/primitives/src/channel.rs
+++ b/primitives/src/channel.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt, ops::Deref, str::FromStr};
+use std::{fmt, ops::Deref, str::FromStr};
 
 use ethereum_types::U256;
 
@@ -7,7 +7,7 @@ use serde_hex::{SerHex, StrictPfx};
 
 use hex::{FromHex, FromHexError};
 
-use crate::{chain::Chain, config::TokenInfo, Address, Validator, ValidatorId};
+use crate::{Address, Validator, ValidatorId};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Copy, Clone, Hash)]
 #[serde(transparent)]
@@ -88,12 +88,6 @@ impl FromStr for ChannelId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         validate_channel_id(s).map(ChannelId)
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ChainContext {
-    pub token: TokenInfo,
-    pub chain: Chain,
 }
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -195,46 +189,6 @@ impl Serialize for Nonce {
         S: serde::Serializer,
     {
         self.0.to_string().serialize(serializer)
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum ChannelError {
-    InvalidArgument(String),
-    /// When the Adapter address is not listed in the `channel.spec.validators`
-    /// which in terms means, that the adapter shouldn't handle this Channel
-    AdapterNotIncluded,
-    /// when `channel.valid_until` has passed (< now), the channel should be handled
-    InvalidValidUntil(String),
-    UnlistedValidator,
-    UnlistedCreator,
-    UnlistedAsset,
-    MinimumValidatorFeeNotMet,
-    FeeConstraintViolated,
-}
-
-impl fmt::Display for ChannelError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ChannelError::InvalidArgument(error) => write!(f, "{}", error),
-            ChannelError::AdapterNotIncluded => write!(f, "channel is not validated by us"),
-            ChannelError::InvalidValidUntil(error) => write!(f, "{}", error),
-            ChannelError::UnlistedValidator => write!(f, "validators are not in the whitelist"),
-            ChannelError::UnlistedCreator => write!(f, "channel.creator is not whitelisted"),
-            ChannelError::UnlistedAsset => write!(f, "channel.depositAsset is not whitelisted"),
-            ChannelError::MinimumValidatorFeeNotMet => {
-                write!(f, "channel validator fee is less than MINIMAL_FEE")
-            }
-            ChannelError::FeeConstraintViolated => {
-                write!(f, "total fees <= deposit: fee constraint violated")
-            }
-        }
-    }
-}
-
-impl Error for ChannelError {
-    fn cause(&self) -> Option<&dyn Error> {
-        None
     }
 }
 

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(unstable_name_collisions)]
 use std::{error, fmt};
 
+#[doc(inline)]
 pub use self::{
     ad_slot::AdSlot,
     ad_unit::AdUnit,
@@ -159,6 +160,7 @@ mod deposit {
 }
 
 pub mod util {
+    #[doc(inline)]
     pub use api::ApiUrl;
 
     pub mod api;

--- a/primitives/src/targeting.rs
+++ b/primitives/src/targeting.rs
@@ -4,6 +4,7 @@ pub use eval::*;
 use serde_json::Number;
 use std::collections::HashMap;
 
+#[doc(inline)]
 pub use input::{field::GetField, Input};
 
 mod eval;

--- a/primitives/src/validator.rs
+++ b/primitives/src/validator.rs
@@ -9,6 +9,7 @@ use crate::{
     Address, DomainError, ToETHChecksum, ToHex, UnifiedNum,
 };
 
+#[doc(inline)]
 pub use messages::*;
 
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
- primitives - add `#[doc(inline)]`
- primitives - channel - remove old structs
- adview-manager - fix rustdoc warning