### PR TITLE
Sentry validator messages routes to axum

### DIFF
--- a/docker-compose.harness.yml
+++ b/docker-compose.harness.yml
@@ -13,9 +13,10 @@ services:
       POSTGRES_USER: 'postgres'
       POSTGRES_PASSWORD: 'postgres'
       # harness_* databases are used by the `test_harness` crate for testing
-      # `sentry_leader` is the default database used by `sentry` for running tests
+      # `sentry_leader` is the default database used by `sentry` for running tests and the leader
+      # `sentry_leader` is for running the local follower when maunally testing
       # `primitives` is used for running tests in the `primitives` crate
-      POSTGRES_MULTIPLE_DATABASES: harness_leader,harness_follower,sentry_leader,primitives
+      POSTGRES_MULTIPLE_DATABASES: harness_leader,harness_follower,sentry_leader,sentry_follower,primitives
     networks:
       - adex-external
 

--- a/sentry/src/middleware/campaign.rs
+++ b/sentry/src/middleware/campaign.rs
@@ -10,6 +10,14 @@ use axum::{
 };
 use hyper::{Body, Request};
 use primitives::{campaign::Campaign, CampaignId, ChainOf};
+use serde::Deserialize;
+
+/// This struct is required because of routes that have more parameters
+/// apart from the `CampaignId`
+#[derive(Debug, Deserialize)]
+struct CampaignParam {
+    pub id: CampaignId,
+}
 
 #[derive(Debug)]
 pub struct CampaignLoad;
@@ -80,9 +88,10 @@ where
     let mut request_parts = RequestParts::new(request);
 
     let campaign_id = request_parts
-        .extract::<Path<CampaignId>>()
+        .extract::<Path<CampaignParam>>()
         .await
-        .map_err(|_| ResponseError::BadRequest("Bad Campaign Id".to_string()))?;
+        .map_err(|_| ResponseError::BadRequest("Bad Campaign Id".to_string()))?
+        .id;
 
     let campaign = fetch_campaign(pool.clone(), &campaign_id)
         .await?

--- a/sentry/src/routes/routers.rs
+++ b/sentry/src/routes/routers.rs
@@ -58,7 +58,7 @@ use super::{
     analytics::{analytics_axum, GET_ANALYTICS_ALLOWED_KEYS},
     channel::{
         channel_dummy_deposit_axum, channel_list_axum, channel_payout_axum,
-        validator_message::list_validator_messages_axum,
+        validator_message::{create_validator_messages_axum, list_validator_messages_axum},
     },
     units_for_slot::post_units_for_slot,
 };
@@ -147,6 +147,11 @@ pub fn channels_router_axum<C: Locked + 'static>() -> Router {
         .route(
             "/pay",
             post(channel_payout_axum::<C>)
+                .route_layer(middleware::from_fn(authentication_required::<C, _>)),
+        )
+        .route(
+            "/validator-messages",
+            post(create_validator_messages_axum::<C>)
                 .route_layer(middleware::from_fn(authentication_required::<C, _>)),
         )
         .route(

--- a/sentry/src/routes/routers.rs
+++ b/sentry/src/routes/routers.rs
@@ -56,7 +56,10 @@ use tower::ServiceBuilder;
 
 use super::{
     analytics::{analytics_axum, GET_ANALYTICS_ALLOWED_KEYS},
-    channel::{channel_dummy_deposit_axum, channel_list_axum, channel_payout_axum},
+    channel::{
+        channel_dummy_deposit_axum, channel_list_axum, channel_payout_axum,
+        validator_message::list_validator_messages_axum,
+    },
     units_for_slot::post_units_for_slot,
 };
 
@@ -145,6 +148,15 @@ pub fn channels_router_axum<C: Locked + 'static>() -> Router {
             "/pay",
             post(channel_payout_axum::<C>)
                 .route_layer(middleware::from_fn(authentication_required::<C, _>)),
+        )
+        .route(
+            "/validator-messages",
+            get(list_validator_messages_axum::<C>),
+        )
+        // We allow Message Type filtering only when filtering by a ValidatorId
+        .route(
+            "/validator-messages/:address/*message_types",
+            get(list_validator_messages_axum::<C>),
         )
         .layer(
             // keeps the order from top to bottom!


### PR DESCRIPTION
TODO:
- [x] Change base branch to `sentry-uses-axum` when #537 is merged