### PR TITLE
Sentry - Channel validator messages types filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
+
+[[package]]
 name = "uuid"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4218,6 +4224,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "urlencoding",
  "wiremock",
 ]
 

--- a/primitives/examples/validator_messages_create_request.rs
+++ b/primitives/examples/validator_messages_create_request.rs
@@ -1,4 +1,4 @@
-use primitives::sentry::ValidatorMessagesCreateRequest;
+use primitives::sentry::validator_messages::ValidatorMessagesCreateRequest;
 use serde_json::{from_value, json};
 
 fn main() {

--- a/primitives/examples/validator_messages_list_query.rs
+++ b/primitives/examples/validator_messages_list_query.rs
@@ -1,4 +1,4 @@
-use primitives::sentry::ValidatorMessagesListQuery;
+use primitives::sentry::validator_messages::ValidatorMessagesListQuery;
 
 fn main() {
     // Empty query - default values only

--- a/primitives/examples/validator_messages_list_response.rs
+++ b/primitives/examples/validator_messages_list_response.rs
@@ -1,4 +1,4 @@
-use primitives::sentry::ValidatorMessagesListResponse;
+use primitives::sentry::validator_messages::ValidatorMessagesListResponse;
 use serde_json::{from_value, json};
 
 fn main() {

--- a/primitives/src/config.rs
+++ b/primitives/src/config.rs
@@ -75,14 +75,14 @@ pub struct Config {
     /// In milliseconds
     #[serde(deserialize_with = "milliseconds_to_std_duration")]
     pub wait_time: Duration,
-    /// The maximum allowed limit of [`ValidatorMessage`](crate::sentry::ValidatorMessage)s per page
+    /// The maximum allowed limit of [`ValidatorMessage`](crate::sentry::validator_messages::ValidatorMessage)s per page
     /// returned by Sentry's GET `/v5/channel/0xXXX.../validator-messages` route.
     ///
     /// Request query also has a `limit` parameter, which can be used to return
     /// <= `msgs_find_limit` messages in the request.
     ///
-    /// Also see: [`ValidatorMessagesListResponse`](crate::sentry::ValidatorMessagesListResponse),
-    /// [`ValidatorMessagesListQuery`](crate::sentry::ValidatorMessagesListQuery)
+    /// Also see: [`ValidatorMessagesListResponse`](crate::sentry::validator_messages::ValidatorMessagesListResponse),
+    /// [`ValidatorMessagesListQuery`](crate::sentry::validator_messages::ValidatorMessagesListQuery)
     pub msgs_find_limit: u32,
     /// The maximum allowed limit of [`FetchedAnalytics`](crate::sentry::FetchedAnalytics)s per page
     /// returned by Sentry's GET `/v5/analytics` routes:

--- a/sentry/src/db/validator_message.rs
+++ b/sentry/src/db/validator_message.rs
@@ -3,8 +3,8 @@ use tokio_postgres::types::ToSql;
 
 use primitives::{
     balances::UncheckedState,
-    sentry::{MessageResponse, ValidatorMessage},
-    validator::{ApproveState, Heartbeat, MessageTypes, NewState},
+    sentry::{message::MessageResponse, validator_messages::ValidatorMessage},
+    validator::{ApproveState, Heartbeat, MessageType, MessageTypes, NewState},
     Channel, ChannelId, ValidatorId,
 };
 
@@ -39,7 +39,7 @@ pub async fn get_validator_messages(
     pool: &DbPool,
     channel_id: &ChannelId,
     validator_id: &Option<ValidatorId>,
-    message_types: &[String],
+    message_types: &[MessageType],
     limit: u64,
 ) -> Result<Vec<ValidatorMessage>, PoolError> {
     let client = pool.get().await?;
@@ -69,7 +69,7 @@ pub async fn get_validator_messages(
 fn add_message_types_params<'a>(
     where_clauses: &mut Vec<String>,
     params: &mut Vec<&'a (dyn ToSql + Sync)>,
-    message_types: &'a [String],
+    message_types: &'a [MessageType],
 ) {
     let mut msg_prep = vec![];
     for message_type in message_types.iter() {

--- a/sentry/src/routes.rs
+++ b/sentry/src/routes.rs
@@ -139,9 +139,9 @@
 //!
 //! The route is handled by [`channel::validator_message::list_validator_messages()`].
 //!
-//! Request query parameters: [`ValidatorMessagesListQuery`](primitives::sentry::ValidatorMessagesListQuery)
+//! Request query parameters: [`ValidatorMessagesListQuery`](primitives::sentry::validator_messages::ValidatorMessagesListQuery)
 //!
-//! Response: [`ValidatorMessagesListResponse`](primitives::sentry::ValidatorMessagesListResponse)
+//! Response: [`ValidatorMessagesListResponse`](primitives::sentry::validator_messages::ValidatorMessagesListResponse)
 //!
 //! ##### Examples
 //!
@@ -167,7 +167,7 @@
 //!
 //! The route is handled by [`channel::validator_message::create_validator_messages()`].
 //!
-//! Request body (json): [`ValidatorMessagesCreateRequest`](primitives::sentry::ValidatorMessagesCreateRequest)
+//! Request body (json): [`ValidatorMessagesCreateRequest`](primitives::sentry::validator_messages::ValidatorMessagesCreateRequest)
 //!
 //! Response: [`SuccessResponse`]
 //!

--- a/sentry/src/routes/routers.rs
+++ b/sentry/src/routes/routers.rs
@@ -108,9 +108,13 @@ pub fn channels_router<C: Locked + 'static>() -> Router {
                 .route_layer(middleware::from_fn(authentication_required::<C, _>)),
         )
         .route("/validator-messages", get(list_validator_messages::<C>))
+        .route(
+            "/validator-messages/:address",
+            get(list_validator_messages::<C>),
+        )
         // We allow Message Type filtering only when filtering by a ValidatorId
         .route(
-            "/validator-messages/:address/*message_types",
+            "/validator-messages/:address/:message_types",
             get(list_validator_messages::<C>),
         )
         .layer(

--- a/test_harness/src/lib.rs
+++ b/test_harness/src/lib.rs
@@ -243,7 +243,7 @@ mod tests {
         },
         unified_num::FromWhole,
         util::{logging::new_logger, ApiUrl},
-        validator::{ApproveState, Heartbeat, NewState, RejectState},
+        validator::{ApproveState, Heartbeat, MessageType, NewState, RejectState},
         Balances, BigNum, Campaign, CampaignId, ChainId, Channel, ChannelId, UnifiedNum,
     };
     use reqwest::{Client, StatusCode};
@@ -1252,7 +1252,7 @@ mod tests {
         // Total: 5.00075 TOKENs
         {
             let latest_new_state_leader = follower_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["NewState"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::NewState])
                 .await
                 .expect("Should fetch NewState from Channel's Leader (Who am I) in FOLLOWER sentry")
                 .map(|message| {
@@ -1262,7 +1262,7 @@ mod tests {
                 .expect("Should have a NewState in Channel's Leader for the Campaign 2 channel");
 
             let latest_reject_state_follower = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["RejectState"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::RejectState])
                 .await
                 .expect(
                     "Should successfully try to fetch a RejectState from Channel's Follower (Who am I) in LEADER sentry",
@@ -1306,7 +1306,7 @@ mod tests {
         {
             // Channel 1
             let _channel_1_heartbeat = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_1.channel.id(), &["Heartbeat"])
+                .get_our_latest_msg(CAMPAIGN_1.channel.id(), &[MessageType::Heartbeat])
                 .await
                 .expect("Should fetch Heartbeat from Leader")
                 .map(|message| Heartbeat::try_from(message).expect("Should be Heartbeat"))
@@ -1314,7 +1314,7 @@ mod tests {
 
             // Channel 2
             let _channel_2_heartbeat = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["Heartbeat"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::Heartbeat])
                 .await
                 .expect("Should fetch Heartbeat from Leader")
                 .map(|message| Heartbeat::try_from(message).expect("Should be Heartbeat"))
@@ -1322,7 +1322,7 @@ mod tests {
 
             // Channel 3
             let _channel_3_heartbeat = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_3.channel.id(), &["Heartbeat"])
+                .get_our_latest_msg(CAMPAIGN_3.channel.id(), &[MessageType::Heartbeat])
                 .await
                 .expect("Should fetch Heartbeat from Leader")
                 .map(|message| Heartbeat::try_from(message).expect("Should be Heartbeat"))
@@ -1597,7 +1597,7 @@ mod tests {
         // Assert that it exists in both validators
         {
             let latest_new_state_leader = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_1.channel.id(), &["NewState"])
+                .get_our_latest_msg(CAMPAIGN_1.channel.id(), &[MessageType::NewState])
                 .await
                 .expect("Should fetch NewState from Leader (Who am I) in Leader sentry")
                 .map(|message| {
@@ -1767,7 +1767,7 @@ mod tests {
         // Ganache health_unsignable_promilles = 750
         {
             let latest_reject_state_follower = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["RejectState"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::RejectState])
                 .await
                 .expect(
                     "Should fetch RejectState from Channel's Follower (Who am I) in Leader sentry",
@@ -1804,7 +1804,7 @@ mod tests {
         // Assert that it exists in both validators
         {
             let latest_new_state_leader = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_3.channel.id(), &["NewState"])
+                .get_our_latest_msg(CAMPAIGN_3.channel.id(), &[MessageType::NewState])
                 .await
                 .expect("Should fetch NewState from Leader (Who am I) in Leader sentry")
                 .map(|message| {
@@ -2034,7 +2034,7 @@ mod tests {
 
         {
             let latest_approve_state_follower = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["ApproveState"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::ApproveState])
                 .await
                 .expect(
                     "Should fetch ApproveState from Channel's Follower (Who am I) from LEADER sentry",
@@ -2046,7 +2046,7 @@ mod tests {
                 .expect("Should have a ApproveState in Channel's Follower for the Campaign 2 channel");
 
             let latest_new_state_leader = follower_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["NewState"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::NewState])
                 .await
                 .expect(
                     "Should fetch NewState from Channel's Leader (Who am I) from FOLLOWER sentry",
@@ -2126,7 +2126,7 @@ mod tests {
         //
         {
             let latest_approve_state_follower = leader_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["ApproveState"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::ApproveState])
                 .await
                 .expect(
                     "Should fetch ApproveState from Channel's Follower (Who am I) from LEADER sentry",
@@ -2143,7 +2143,7 @@ mod tests {
             );
 
             let latest_new_state_leader = follower_sentry
-                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &["NewState"])
+                .get_our_latest_msg(CAMPAIGN_2.channel.id(), &[MessageType::NewState])
                 .await
                 .expect(
                     "Should fetch NewState from Channel's Leader (Who am I) from FOLLOWER sentry",

--- a/validator_worker/Cargo.toml
+++ b/validator_worker/Cargo.toml
@@ -38,6 +38,9 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_qs = "0.10"
+# For encoding the MessageTypesFilter value
+urlencoding = "2"
+
 toml = "0.5"
 # CLI
 clap = { version = "3", features = ["cargo"] }

--- a/validator_worker/src/heartbeat.rs
+++ b/validator_worker/src/heartbeat.rs
@@ -4,7 +4,7 @@ use adapter::{prelude::*, util::get_signable_state_root, Error as AdapterError};
 use byteorder::{BigEndian, ByteOrder};
 use primitives::{
     merkle_tree::MerkleTree,
-    validator::{Heartbeat, MessageTypes},
+    validator::{Heartbeat, MessageType, MessageTypes},
     ChainOf, Channel,
 };
 use thiserror::Error;
@@ -28,7 +28,7 @@ pub async fn heartbeat<C: Unlocked + 'static>(
     channel_context: &ChainOf<Channel>,
 ) -> Result<HeartbeatStatus, Error> {
     let validator_message_response = iface
-        .get_our_latest_msg(channel_context.context.id(), &["Heartbeat"])
+        .get_our_latest_msg(channel_context.context.id(), &[MessageType::Heartbeat])
         .await?;
     let heartbeat_msg = match validator_message_response {
         Some(MessageTypes::Heartbeat(heartbeat)) => Some(heartbeat),
@@ -85,7 +85,10 @@ mod test {
     use chrono::{Duration, Utc};
     use primitives::{
         config::GANACHE_CONFIG,
-        sentry::{SuccessResponse, ValidatorMessage, ValidatorMessagesListResponse},
+        sentry::{
+            validator_messages::{ValidatorMessage, ValidatorMessagesListResponse},
+            SuccessResponse,
+        },
         test_util::{
             discard_logger, DUMMY_AUTH, DUMMY_CAMPAIGN, DUMMY_VALIDATOR_FOLLOWER,
             DUMMY_VALIDATOR_LEADER, FOLLOWER, IDS, LEADER,

--- a/validator_worker/src/leader.rs
+++ b/validator_worker/src/leader.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use adapter::{prelude::*, Error as AdapterError};
 use primitives::{
     balances::CheckedState,
-    validator::{MessageError, MessageTypes, NewState},
+    validator::{MessageError, MessageType, MessageTypes, NewState},
     Balances, ChainOf, Channel,
 };
 
@@ -51,7 +51,7 @@ pub async fn tick<C: Unlocked + 'static>(
                 false
             } else {
                 let latest_new_state = sentry
-                    .get_our_latest_msg(channel.id(), &["NewState"])
+                    .get_our_latest_msg(channel.id(), &[MessageType::NewState])
                     .await?
                     .map(NewState::<CheckedState>::try_from)
                     .transpose()?;
@@ -138,7 +138,10 @@ mod test {
         balances::UncheckedState,
         campaign::Validators,
         config::GANACHE_CONFIG,
-        sentry::{SuccessResponse, ValidatorMessage, ValidatorMessagesListResponse},
+        sentry::{
+            validator_messages::{ValidatorMessage, ValidatorMessagesListResponse},
+            SuccessResponse,
+        },
         test_util::{
             discard_logger, ADVERTISER, CREATOR, DUMMY_AUTH, DUMMY_CAMPAIGN,
             DUMMY_VALIDATOR_FOLLOWER, DUMMY_VALIDATOR_LEADER, FOLLOWER, IDS, LEADER, PUBLISHER,


### PR DESCRIPTION
Part of #540 

sentry - validator messages:
- list validator messages - MessageTypesFilter
- primitives - sentry - MessageTypesFilter
- primitives - sentry - create validator_messages module
- validator_worker - SentryApi - use MessageType
- validator_worker - leader, follower & heartbeat ticks
- validator_worker - Cargo - add urlencoding for MessageTypesFilter